### PR TITLE
Build offline-friendly docs for VIPM distribution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  build-online:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -25,17 +25,52 @@ jobs:
         run: uv python install
       - name: Sync dependencies
         run: uv sync
-      - run: uv run mkdocs build --strict
+      - name: Build online docs
+        run: uv run mkdocs build --strict
       - name: Upload site artifact
         uses: actions/upload-artifact@v4
         with:
-          name: site-pr-${{ github.event.pull_request.number || github.run_number }}
+          name: site-online-pr-${{ github.event.pull_request.number || github.run_number }}
           path: site/
           retention-days: 7
 
+  build-offline:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+      - name: Set up Python
+        run: uv python install
+      - name: Sync dependencies
+        run: uv sync
+      - name: Create offline config
+        run: |
+          cat > mkdocs-offline.yml << 'EOF'
+          INHERIT: mkdocs.yml
+          use_directory_urls: false
+          EOF
+      - name: Build offline docs
+        run: uv run mkdocs build -f mkdocs-offline.yml -d help --strict
+      - name: Create offline package
+        run: |
+          cd help
+          zip -r ../vipm-help-offline.zip .
+          cd ..
+      - name: Upload offline package
+        uses: actions/upload-artifact@v4
+        with:
+          name: vipm-help-offline-${{ github.event.pull_request.number || github.run_number }}
+          path: vipm-help-offline.zip
+          retention-days: 90
+
   deploy:
     runs-on: ubuntu-latest
-    needs: build
+    needs: build-online
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     permissions:
       contents: write
@@ -53,7 +88,7 @@ jobs:
 
   comment-preview:
     runs-on: ubuntu-latest
-    needs: build
+    needs: [build-online, build-offline]
     if: github.event_name == 'pull_request'
     permissions:
       pull-requests: write
@@ -64,17 +99,23 @@ jobs:
           script: |
             const comment = `## ✅ Documentation Build Successful
             
-            The documentation has been successfully built for this PR!
+            The documentation has been successfully built for this PR in both online and offline formats!
             
-            📦 **Built Site Artifact:** Available in the workflow run
-            🔗 **Workflow Run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            ### 🌐 Online Version (GitHub Pages)
+            📦 **Artifact:** \`site-online-pr-${{ github.event.pull_request.number }}\`
+            - Use with a web server: \`python -m http.server\`
             
-            You can download the built site artifact from the workflow run to preview the changes locally.
+            ### 💾 Offline Version (for VIPM distribution)
+            📦 **Artifact:** \`vipm-help-offline-${{ github.event.pull_request.number }}.zip\`
+            - Works by double-clicking \`index.html\`
+            - Ready to bundle with VIPM installer
             
-            To preview locally:
-            1. Download the \`site-pr-${{ github.event.pull_request.number }}\` artifact from the workflow run
+            🔗 **Download artifacts from:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            
+            #### To preview offline docs locally:
+            1. Download \`vipm-help-offline-${{ github.event.pull_request.number }}.zip\`
             2. Extract the zip file
-            3. Open \`index.html\` in your browser or serve with \`python -m http.server\``;
+            3. Double-click \`index.html\` to open in browser`;
             
             github.rest.issues.createComment({
               issue_number: context.issue.number,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,29 +93,27 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - name: Comment PR with artifact info
+      - name: Comment on PR
         uses: actions/github-script@v7
         with:
           script: |
-            const comment = `## ✅ Documentation Build Successful
+            const comment = `## Documentation Build Successful
             
-            The documentation has been successfully built for this PR in both online and offline formats!
+            Built in both online and offline formats.
             
-            ### 🌐 Online Version (GitHub Pages)
-            📦 **Artifact:** \`site-online-pr-${{ github.event.pull_request.number }}\`
+            **Online Version (GitHub Pages)**
+            - Artifact: \`site-online-pr-${{ github.event.pull_request.number }}\`
             - Use with a web server: \`python -m http.server\`
             
-            ### 💾 Offline Version (for VIPM distribution)
-            📦 **Artifact:** \`vipm-help-offline-${{ github.event.pull_request.number }}.zip\`
+            **Offline Version (for VIPM distribution)**
+            - Artifact: \`vipm-help-offline-${{ github.event.pull_request.number }}.zip\`
             - Works by double-clicking \`index.html\`
-            - Ready to bundle with VIPM installer
             
-            🔗 **Download artifacts from:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            **Download artifacts:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
             
-            #### To preview offline docs locally:
+            **To test offline:**
             1. Download \`vipm-help-offline-${{ github.event.pull_request.number }}.zip\`
-            2. Extract the zip file
-            3. Double-click \`index.html\` to open in browser`;
+            2. Extract and open \`index.html\``;
             
             github.rest.issues.createComment({
               issue_number: context.issue.number,


### PR DESCRIPTION
## Add Offline Documentation Build

### Summary
Adds offline-friendly documentation build for bundling with VIPM installations.

This PR scopes the level of effort required to build offline documentation (replacing CHM files) for use in VIPM.

### Changes
- New `build-offline` job creates `vipm-help-offline.zip` with flat URLs
- Works offline by double-clicking `index.html` (no web server needed)
- Supports Windows and Linux (replaces Windows-only CHM files)
- Online docs deployment unchanged

### Testing
Download `vipm-help-offline-XXX.zip` artifact, extract, and open `index.html`

### Artifacts
- `site-online-pr-XXX` - Web version for GitHub Pages
- `vipm-help-offline-XXX.zip` - Offline version for VIPM distribution