### PR TITLE
Add SBOM documentation and update preview for 2026 Q3

### DIFF
--- a/docs/.snippets/sbom-preview.md
+++ b/docs/.snippets/sbom-preview.md
@@ -1,0 +1,4 @@
+!!! info "Preview Feature — Available in VIPM 2026 Q3 Preview"
+
+    The SBOM and sync commands are available in the **[VIPM 2026 Q3 Preview](../preview.md)**.
+    Download it to try these features and share your feedback.

--- a/docs/cli/command-reference.md
+++ b/docs/cli/command-reference.md
@@ -31,6 +31,8 @@ Unless a command states otherwise, it returns exit code `0` on success and a non
 | [`vipm package-list-refresh`](#vipm-package-list-refresh) | Refresh repository metadata (legacy command, still supported). |
 | [`vipm activate`](#vipm-activate) | Activate VIPM Pro using a serial number, name, and email. |
 | [`vipm build`](#vipm-build) | Build packages from `.vipb` specs or LabVIEW project build specs. |
+| [`vipm sbom`](#vipm-sbom) | Generate a CycloneDX SBOM from a project or manifest. |
+| [`vipm sync`](#vipm-sync) | Reconcile vipm.toml from a LabVIEW project scan. |
 | [`vipm version`](#vipm-version) | Output the CLI and Desktop version numbers. |
 | [`vipm about`](#vipm-about) | Print installation details (paths, versions). |
 
@@ -284,6 +286,139 @@ Building VI Package from path/to/your_package.vipb
 - **Linux build limitations**: Review the [VIPM Preview docs](../preview.md) for current platform support notes.
 - **Missing dependencies**: Run `vipm install project.vipc` before invoking `vipm build` in CI.
 
+## `vipm sbom`
+
+--8<-- "sbom-preview.md"
+
+Generates a [CycloneDX](https://cyclonedx.org/) Software Bill of Materials (SBOM) from a project file or manifest. See the [SBOM documentation](../sbom/index.md) for a tutorial and workflow guidance.
+
+### Syntax
+
+```bash
+vipm sbom [INPUT] --format cyclonedx --schema-version 1.5 --output <PATH> [OPTIONS]
+```
+
+`INPUT` is a `vipm.toml`, `.lvproj`, `.dragon`, or `.vipc` file. If omitted, the CLI searches upward for a `vipm.toml`.
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `--format cyclonedx` | **Required.** Output format. |
+| `--schema-version 1.5` | **Required.** CycloneDX spec version for the output document. |
+| `--output <PATH>` | **Required.** File path for the generated SBOM (relative or absolute). |
+| `--product-name <NAME>` | Sets `metadata.component.name` in the SBOM. Defaults to the input filename stem. |
+| `--product-version <VERSION>` | Sets `metadata.component.version`. Omitted from the SBOM if not provided. |
+| `--product-type <TYPE>` | Sets `metadata.component.type`. One of: `application` (default), `library`, `framework`, `container`, `firmware`, `device`, `file`. |
+| `--document-version <N>` | BOM revision number (default: `1`). |
+| `--document-serial-number <URN>` | Unique BOM identifier (`urn:uuid:...`). Auto-generated if omitted. |
+| `--no-vipm` | Exclude VIPM packages from the SBOM. |
+| `--no-nipm` | Exclude NI packages (NIPM) from the SBOM. |
+| `--no-dev` | Exclude dev-dependencies (`vipm.toml` input only). |
+| `--follow-linker` | Follow the VI linker to discover subVI dependencies (`.lvproj` input only). |
+| `--follow-depth <N>` | Linker traversal depth limit. Requires `--follow-linker`. |
+
+### Examples
+
+Generate an SBOM from a LabVIEW project:
+
+```bash
+vipm sbom MyProject.lvproj \
+  --format cyclonedx \
+  --schema-version 1.5 \
+  --product-name "My Instrument" \
+  --product-version 2.1.0 \
+  --output build/bom.json
+```
+
+Generate from a vipm.toml, excluding dev-dependencies:
+
+```bash
+vipm sbom vipm.toml \
+  --format cyclonedx \
+  --schema-version 1.5 \
+  --no-dev \
+  --output build/bom.json
+```
+
+Expected output on success:
+
+```
+SBOM written to build/bom.json
+```
+
+### Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | SBOM generated successfully |
+| `1` | Unexpected or unclassified error |
+| `2` | Invalid arguments or failed input validation |
+| `4` | Requested LabVIEW version is not installed |
+| `6` | Insufficient edition, license, or activation |
+| `8` | File system or IO failure (e.g., cannot write to `--output` path) |
+| `13` | Input file is not a supported type |
+| `14` | Input file exists but is malformed |
+| `15` | A required file does not exist |
+
+Any non-zero exit code means the SBOM was **not** produced. The `--output` file is only written on exit code `0`.
+
+On failure, stderr contains a human-readable error message. Example:
+
+```
+error: No LabVIEW installation found for version '2024'.
+help: Use 'vipm labview-list' to see available versions
+```
+
+### Common Issues
+
+- **Missing required flags**: `--format`, `--schema-version`, and `--output` are always required — there are no defaults.
+- **Wrong LabVIEW version**: Use `--labview-version` and `--labview-bitness` to target the correct installation when scanning `.lvproj` files.
+- **`--no-dev` on non-toml input**: The `--no-dev` flag is only valid with `vipm.toml` input.
+
+## `vipm sync`
+
+--8<-- "sbom-preview.md"
+
+Reconciles a `vipm.toml` manifest from the dependencies discovered in a LabVIEW project scan.
+
+### Syntax
+
+```bash
+vipm sync [TARGET] --from <SOURCE> [OPTIONS]
+```
+
+`TARGET` is the `vipm.toml` to update. If omitted, the CLI searches upward from the current directory. `SOURCE` is the file to scan (e.g., a `.lvproj`).
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `--from <SOURCE>` | **Required.** The source file to scan for dependencies. |
+| `--dry-run` | Preview changes without writing to the manifest. |
+| `--no-vipm` | Exclude VIPM packages from the sync. |
+| `--no-nipm` | Exclude NI packages (NIPM) from the sync. |
+| `--follow-linker` | Follow the VI linker to discover subVI dependencies. |
+| `--follow-depth <N>` | Linker traversal depth limit. Requires `--follow-linker`. |
+
+### Examples
+
+Sync vipm.toml from a LabVIEW project:
+
+```bash
+vipm sync --from MyProject.lvproj
+```
+
+Preview changes without writing:
+
+```bash
+vipm sync --from MyProject.lvproj --dry-run
+```
+
+### Common Issues
+
+- **No vipm.toml found**: Either specify the target path explicitly or run the command from a directory that contains (or is a child of a directory that contains) a `vipm.toml`.
+
 ## `vipm version`
 
 Prints the VIPM CLI and Desktop versions. Useful for support tickets and automation logs.
@@ -312,6 +447,7 @@ Use `vipm about --help` to review the latest options.
 ## Related Resources
 
 - [Getting Started](getting-started.md)
+- [SBOM Generation](../sbom/index.md)
 - [Docker and Containers](docker.md)
 - [GitHub Actions and CI/CD](github-actions.md)
 - Project plan: `dev-docs/cli-docs-improvement-proposal.md`

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -4,7 +4,7 @@ title: Overview
 
 --8<-- "preview-available.md"
 
-VIPM includes a powerful command-line interface (CLI) that enables automation, integration with CI/CD pipelines, and usage in containerized environments.
+VIPM includes a powerful command-line interface (CLI) that enables automation, integration with CI/CD pipelines, and usage in containerized environments. The CLI also supports [SBOM generation](../sbom/index.md) for producing CycloneDX software inventories of your LabVIEW projects.
 
 ## Example Commands
 

--- a/docs/preview.md
+++ b/docs/preview.md
@@ -1,6 +1,4 @@
-# VIPM 2026Q1 Preview 3
-
-Watch our [overview video](https://www.youtube.com/watch?v=2vHFfQF0agc) to see the new features and improvements in this preview release.
+# VIPM 2026 Q3 Preview 1
 
 ## Installation & Feedback
 
@@ -26,85 +24,37 @@ Report issues on [GitHub](https://github.com/vipm-io/vipm-desktop-issues/issues)
 
 ## What's New
 
-### Updates in Preview 3
-This release focuses on polish and bug fixes based on community feedback:
+### CycloneDX SBOM Generation
 
-**VIPM Desktop Improvements:**
+Generate a [CycloneDX](https://cyclonedx.org/) 1.5 Software Bill of Materials (SBOM) for your LabVIEW project with a single command. The SBOM includes VIPM packages, NI packages (NIPM), enriched metadata (licenses, descriptions, vendors), and cryptographic hashes (SHA-256, MD5).
 
-- **Fixed "Search Online" button alignment**: Corrected alignment of the "Search Online" button in the window that appears when no packages are available for search results
-- **Fixed destination deletion text issue**: Resolved issue where deleting a custom VI Package Builder destination would leave previously selected text white
-- **Improved installer window behavior**: The Updates Installer window now stays visible instead of hiding to the System Tray, making installation progress clearly visible
+SBOMs are increasingly required for regulatory compliance, including the [EU Cyber Resilience Act (CRA)](https://jki.net/cra/). See the [SBOM documentation](sbom/index.md) for details.
 
-**VIPM CLI Improvements:**
+```bash
+vipm sbom MyProject.lvproj \
+  --format cyclonedx \
+  --schema-version 1.5 \
+  --product-name "My Instrument" \
+  --product-version 2.1.0 \
+  --output build/bom.json
+```
 
-- **Fixed `vipm about` initialization error**: The `vipm about` command now prints all fields and outputs a warning when VIPM Desktop is not fully initialized (such as on first startup)
-- **Added Global Options to command help**: Running `--help` for individual commands (e.g., `vipm build --help`) now displays Global Options in addition to command-specific options
-- **Fixed LabVIEW version reporting**: The `vipm build LVPROJ_FILE` command now correctly reports the LabVIEW version being used
-- **Fixed output line formatting**: Resolved issue where `vipm build LVPROJ_FILE` output would sometimes garble multiple lines together into a single line
+**[Get started with SBOM generation →](sbom/getting-started.md)**
 
-### Updates in Preview 2
+### Manifest Sync (vipm sync)
 
-- **VI Package building officially supported on Linux**: Build .vip packages natively on Linux systems
-- **Multi-platform .vipb files**: Package build files (.vipb) now work seamlessly across Windows and Linux
-- **Improved Linux support for RHEL**: Native RPM packages for Red Hat Enterprise Linux and derivatives
-- **Fixed .dragon and .vip installation**: Resolved issues with VIPM CLI when installing .dragon and .vip files
-- **Case-insensitive library name handling**: VIPM now handles internal library name changes in a case-insensitive manner
-- **LabVIEW Class default menu support**: Re-added support for LabVIEW Class default menu items
+Keep your `vipm.toml` manifest in sync with the dependencies discovered in a LabVIEW project:
 
-### LabVIEW 2026 Support
-This preview release has been tested with LabVIEW 2026 Beta and includes full LabVIEW 2026 support. You can access the LabVIEW 2026 Beta at the [LabVIEW Beta forum](https://forums.ni.com/t5/LabVIEW-Beta/ct-p/7035).
+```bash
+vipm sync --from MyProject.lvproj
+```
 
-### Improved Support for Installing VIPM on Linux
-
-VIPM is now available as native Linux packages for seamless installation and updates:
-
-- **DEB Packages** - Native support for Debian-based distributions (Ubuntu, Debian, Linux Mint, and derivatives)
-
-- **RPM Packages** - Native support for Red Hat-based distributions (RHEL, Fedora, CentOS, Rocky Linux, and derivatives)
-
-### VIPM Command Line Interface (CLI)
-
-The new VIPM CLI brings powerful automation capabilities to your package management workflows. Install, update, and remove packages from the command line, integrate VIPM operations into build scripts and CI/CD pipelines, and automate package management tasks across multiple systems.
-
-Once installed, try out VIPM CLI by opening a terminal and typing `vipm`.
-
-### vipm.toml Project Configuration (Preview Feature)
-
-Manage your LabVIEW project's dependencies and builds with a modern, human-readable `vipm.toml` configuration file. Features include declarative dependency management, reproducible builds via lock files, and seamless CI/CD integration.
-
-**[Get started with vipm.toml →](vipm-toml/getting-started.md)**
-
-### Faster Downloads and Improved Stability (Preview Feature)
-
-VIPM now uses a modernized HTTP client for improved package repository communication and download performance. This preview feature lays the groundwork for enhanced reliability and future capabilities.
-
-### Bug Fixes and Usability Improvements
-Various bug and usability fixes including:
-
-* LabVIEW Libraries (lvlib) that contain support files now correctly point to the correct location. Thank you to GitHub users @NatanBiesmans and @AlexanderElbert for reporting this issue.
-* Improved Linux workflows. Thank you to GitHub users @pesmith8a and @JamesMc86 for reporting this issue.
-* Fixed issue where similar VIPB destination names become linked. Thank you to GitHub user @qalldredge for reporting this issue.
-* "Place folder contents in destination" now works for support files. Thank you to GitHub user @Sdusing7 for reporting this issue.
-
-  > This is a preview feature. Enable this through Options > Preview Features and select "[Bug Fix] Place Folder Contents for Non-LabVIEW Files".
-
---8<-- "need-help.md"    
+Preview changes before writing with `--dry-run`. See the [CLI Command Reference](cli/command-reference.md#vipm-sync) for full options.
 
 ---
 
-## Thank You to Our Community
+## Feedback
 
-Thank you to everyone who has been testing the VIPM 2026Q1 Preview! Your feedback and testing efforts are invaluable in helping us improve the product.
+Thank you to everyone testing VIPM previews! Your feedback is invaluable in helping us improve the product.
 
-Please continue to report any issues you encounter:
-
-**Feedback**
 Report issues on [GitHub](https://github.com/vipm-io/vipm-desktop-issues/issues) or join us on [Discord](https://discord.gg/GCB7QQyzsP)
-
-We appreciate your ongoing support and contributions to making VIPM better for the entire LabVIEW community!
-
----
-
-**Page last edited:** November 19, 2025
-
----

--- a/docs/release-notes/2026.1.md
+++ b/docs/release-notes/2026.1.md
@@ -1,0 +1,47 @@
+---
+title: VIPM 2026 Q1 - Release Notes
+---
+
+# VIPM 2026 Q1
+
+VIPM 2026 Q1 introduces the VIPM Command Line Interface (CLI), native Linux packages, LabVIEW 2026 support, and the vipm.toml project configuration format.
+
+## VIPM Command Line Interface (CLI)
+
+A new CLI brings automation capabilities to LabVIEW package management. Install, update, and remove packages from the command line, integrate VIPM into build scripts and CI/CD pipelines, and automate package management across multiple systems.
+
+The CLI ships with every edition of VIPM Desktop. See the [CLI documentation](../cli/index.md) to get started.
+
+## vipm.toml Project Configuration (Preview)
+
+Manage your LabVIEW project's dependencies and builds with a human-readable `vipm.toml` configuration file. Features include declarative dependency management, reproducible builds via lock files, and CI/CD integration.
+
+See [vipm.toml Getting Started](../vipm-toml/getting-started.md) for details.
+
+## Native Linux Packages
+
+VIPM is now available as native Linux packages:
+
+- **DEB packages** for Debian-based distributions (Ubuntu, Debian, Linux Mint, and derivatives)
+- **RPM packages** for Red Hat-based distributions (RHEL, Fedora, CentOS, Rocky Linux, and derivatives)
+
+VI Package building is officially supported on Linux, and `.vipb` build files work across Windows and Linux.
+
+## LabVIEW 2026 Support
+
+Full support for LabVIEW 2026.
+
+## Additional improvements
+
+- Faster package downloads via modernized HTTP client
+- Multi-platform `.vipb` files work across Windows and Linux
+- LabVIEW Libraries (lvlib) with support files now point to the correct location
+- Fixed issue where similar VIPB destination names became linked
+- "Place folder contents in destination" now works for support files
+- LabVIEW Class default menu support re-added
+- Case-insensitive library name handling for internal library name changes
+- `vipm about` now prints all fields with a warning when VIPM Desktop is not fully initialized
+- `vipm build` correctly reports the LabVIEW version being used
+- Global options now display in individual command `--help` output
+
+--8<-- "need-help.md"

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -8,6 +8,7 @@ Please select a release from the navbar on the left or choose from one of the it
 
 ## Recent Releases
 
+- [VIPM 2026 Q1](2026.1.md)
 - [VIPM 2025Q3 fix 1 for Windows](2025.3.1.md)
 
 ## Past Releases

--- a/docs/sbom/getting-started.md
+++ b/docs/sbom/getting-started.md
@@ -1,0 +1,104 @@
+---
+title: Getting Started
+---
+
+# Getting Started with SBOM Generation
+
+--8<-- "sbom-preview.md"
+
+This guide walks you through generating your first CycloneDX SBOM with the VIPM CLI.
+
+## Step 1 — Verify the CLI is available
+
+Open a terminal and confirm that VIPM is installed:
+
+```bash
+vipm --version
+```
+
+Expected output:
+
+```
+VIPM CLI version 2026.3.x
+```
+
+If the command is not found, install the [VIPM 2026 Q3 Preview](../preview.md) first.
+
+## Step 2 — Generate an SBOM
+
+Run the `vipm sbom` command against your project. This example uses a `.lvproj` file:
+
+```bash
+vipm sbom "C:\MyProject\MyProject.lvproj" ^
+  --format cyclonedx ^
+  --schema-version 1.5 ^
+  --output "C:\MyProject\build\bom.json"
+```
+
+On Linux or macOS, use backslash line continuations instead:
+
+```bash
+vipm sbom /home/user/MyProject/MyProject.lvproj \
+  --format cyclonedx \
+  --schema-version 1.5 \
+  --output /home/user/MyProject/build/bom.json
+```
+
+Expected output:
+
+```
+SBOM written to C:\MyProject\build\bom.json
+```
+
+The three required flags are `--format`, `--schema-version`, and `--output`. There are no defaults for these — they must always be specified.
+
+## Step 3 — Inspect the output
+
+Open `bom.json` to see the generated CycloneDX document. Key sections include:
+
+- **`metadata.component`** — your product (name, version, type)
+- **`metadata.tools`** — records that VIPM CLI generated the SBOM
+- **`components`** — the list of dependencies, each with a package URL (`purl`), license, vendor, description, and hashes
+
+## Step 4 — Add product metadata
+
+Set your product's name and version so they appear in the SBOM's root component:
+
+```bash
+vipm sbom MyProject.lvproj ^
+  --format cyclonedx ^
+  --schema-version 1.5 ^
+  --product-name "My Instrument" ^
+  --product-version 2.1.0 ^
+  --output build/bom.json
+```
+
+If `--product-name` is omitted, it defaults to the input filename stem (e.g., `MyProject`). If `--product-version` is omitted, the version field is left out of the SBOM.
+
+## Step 5 — Filter dependencies
+
+You can exclude specific dependency sources:
+
+```bash
+# Exclude NI packages, only include VIPM packages
+vipm sbom MyProject.lvproj ^
+  --format cyclonedx ^
+  --schema-version 1.5 ^
+  --no-nipm ^
+  --output build/bom.json
+```
+
+Available filters:
+
+| Flag | Effect |
+|------|--------|
+| `--no-vipm` | Exclude VIPM packages from the SBOM |
+| `--no-nipm` | Exclude NI packages (NIPM) from the SBOM |
+| `--no-dev` | Exclude dev-dependencies (vipm.toml input only) |
+
+## Next steps
+
+- **[Workflows](workflows.md)** — learn about different input types, CI/CD integration, and understanding the CycloneDX output
+- **[CLI Command Reference](../cli/command-reference.md#vipm-sbom)** — full parameter reference including exit codes
+
+--8<-- "need-help.md"

--- a/docs/sbom/index.md
+++ b/docs/sbom/index.md
@@ -1,0 +1,54 @@
+---
+title: SBOM Overview
+---
+
+# Software Bill of Materials (SBOM)
+
+--8<-- "sbom-preview.md"
+
+A Software Bill of Materials (SBOM) is a machine-readable inventory of every software component in your product — including package names, versions, suppliers, licenses, and cryptographic hashes. SBOMs give you and your customers visibility into exactly what ships in your software.
+
+## Why SBOMs matter
+
+Regulations such as the [EU Cyber Resilience Act (CRA)](https://jki.net/cra/) and [US Executive Order 14028](https://www.nist.gov/itl/executive-order-14028-improving-nations-cybersecurity) are making SBOMs a requirement for software products in regulated markets. Beyond compliance, SBOMs support practical goals like license auditing, vulnerability tracking, and supply chain transparency.
+
+## What VIPM generates
+
+The VIPM CLI generates [CycloneDX](https://cyclonedx.org/) 1.5 SBOMs in JSON format. A single command scans your LabVIEW project and produces an SBOM that includes:
+
+- **VIPM packages** — packages installed via VI Package Manager
+- **NI packages (NIPM)** — packages installed via NI Package Manager
+- **Enriched metadata** — display names, descriptions, vendors, license identifiers, and download URLs
+- **Cryptographic hashes** — SHA-256 and MD5 checksums for each component
+- **Product metadata** — your application's name, version, and component type
+
+## Supported inputs
+
+| Input type | Description | LabVIEW required? |
+|------------|-------------|-------------------|
+| `vipm.toml` | Project manifest with declared dependencies | No |
+| `.lvproj` | LabVIEW project file — scans installed packages directly | Yes |
+| `.dragon` | Dragon configuration file | No |
+| `.vipc` | VIPM configuration file | No |
+
+Choose the input that matches your workflow. If your project already uses `vipm.toml`, that's the simplest path — no LabVIEW installation is needed. For existing LabVIEW projects, point directly at your `.lvproj` file. See [Workflows](workflows.md) for guidance on each approach.
+
+## Prerequisites
+
+- **VIPM 2026 Q3 Preview** or later — [download here](../preview.md)
+- **LabVIEW** — required only when generating SBOMs from `.lvproj` files
+- **NI Package Manager** — required only when including NI packages in the SBOM
+
+Verify your CLI is available:
+
+```bash
+vipm --version
+```
+
+## Next steps
+
+- **[Getting Started](getting-started.md)** — generate your first SBOM in a few minutes
+- **[Workflows](workflows.md)** — choose the right approach for your project and environment
+- **[CLI Command Reference](../cli/command-reference.md#vipm-sbom)** — full parameter reference for `vipm sbom`
+
+--8<-- "need-help.md"

--- a/docs/sbom/workflows.md
+++ b/docs/sbom/workflows.md
@@ -1,0 +1,188 @@
+---
+title: Workflows
+---
+
+# SBOM Workflows
+
+--8<-- "sbom-preview.md"
+
+The VIPM CLI supports several input types for SBOM generation. This page helps you choose the right approach for your project and shows how to integrate SBOM generation into CI/CD pipelines.
+
+## Manifest-based generation (vipm.toml)
+
+If your project uses a `vipm.toml` file to declare dependencies, this is the simplest workflow. No LabVIEW installation is needed — the CLI reads the manifest directly.
+
+```bash
+vipm sbom vipm.toml \
+  --format cyclonedx \
+  --schema-version 1.5 \
+  --product-name "My Application" \
+  --product-version 1.0.0 \
+  --output build/bom.json
+```
+
+If you omit the input path, the CLI searches upward from the current directory for a `vipm.toml` file.
+
+### Excluding dev-dependencies
+
+Use `--no-dev` to omit dependencies marked as dev-only in your `vipm.toml`:
+
+```bash
+vipm sbom vipm.toml \
+  --format cyclonedx \
+  --schema-version 1.5 \
+  --no-dev \
+  --output build/bom.json
+```
+
+`--no-dev` is only available with `vipm.toml` input.
+
+### Keeping vipm.toml in sync with your project
+
+Use `vipm sync` to reconcile your `vipm.toml` with the dependencies discovered in a LabVIEW project:
+
+```bash
+vipm sync --from MyProject.lvproj
+```
+
+This updates the `vipm.toml` in your project directory to reflect the packages found in the `.lvproj` file. You can then generate SBOMs from the manifest without needing LabVIEW on your build machine.
+
+Preview changes without writing:
+
+```bash
+vipm sync --from MyProject.lvproj --dry-run
+```
+
+See the [CLI Command Reference](../cli/command-reference.md#vipm-sync) for full `vipm sync` options.
+
+## Project-based generation (.lvproj)
+
+For LabVIEW projects that don't yet use `vipm.toml`, point directly at the `.lvproj` file. The CLI scans the LabVIEW installation to discover installed packages.
+
+```bash
+vipm sbom MyProject.lvproj \
+  --format cyclonedx \
+  --schema-version 1.5 \
+  --output build/bom.json
+```
+
+### Targeting a specific LabVIEW version
+
+If multiple LabVIEW versions are installed, use the global options to select one:
+
+```bash
+vipm sbom MyProject.lvproj \
+  --labview-version 2025 \
+  --labview-bitness 64 \
+  --format cyclonedx \
+  --schema-version 1.5 \
+  --output build/bom.json
+```
+
+### Following the VI linker
+
+For deeper dependency discovery, use `--follow-linker` to trace subVI dependencies through the LabVIEW linker:
+
+```bash
+vipm sbom MyProject.lvproj \
+  --format cyclonedx \
+  --schema-version 1.5 \
+  --follow-linker \
+  --follow-depth 3 \
+  --output build/bom.json
+```
+
+`--follow-depth` sets how many levels deep the linker traversal goes. It requires `--follow-linker` to be set.
+
+## Legacy inputs (.dragon, .vipc)
+
+The CLI also accepts `.dragon` and `.vipc` files as input. These are useful when migrating from older VIPM workflows:
+
+```bash
+vipm sbom project.dragon \
+  --format cyclonedx \
+  --schema-version 1.5 \
+  --output build/bom.json
+```
+
+```bash
+vipm sbom project.vipc \
+  --format cyclonedx \
+  --schema-version 1.5 \
+  --output build/bom.json
+```
+
+## CI/CD integration
+
+SBOM generation fits naturally into build pipelines. The CLI runs headless with no GUI, making it suitable for automated environments.
+
+### Docker
+
+If you already run VIPM in Docker (see [Docker and Containers](../cli/docker.md)), add the `vipm sbom` step after your build:
+
+```bash
+vipm sbom vipm.toml \
+  --format cyclonedx \
+  --schema-version 1.5 \
+  --product-name "$PRODUCT_NAME" \
+  --product-version "$VERSION" \
+  --output /output/bom.json
+```
+
+### GitHub Actions
+
+Add an SBOM generation step to your workflow (see [GitHub Actions and CI/CD](../cli/github-actions.md) for environment setup):
+
+```yaml
+- name: Generate SBOM
+  run: |
+    vipm sbom vipm.toml \
+      --format cyclonedx \
+      --schema-version 1.5 \
+      --product-name "${{ github.event.repository.name }}" \
+      --product-version "${{ github.ref_name }}" \
+      --output build/bom.json
+
+- name: Upload SBOM artifact
+  uses: actions/upload-artifact@v4
+  with:
+    name: sbom
+    path: build/bom.json
+```
+
+### Verifying success in automation
+
+Check the exit code to determine success. Exit code `0` means the SBOM was written; any non-zero code means it was not produced. See the [exit codes table](../cli/command-reference.md#vipm-sbom) for the full list.
+
+## Understanding the CycloneDX output
+
+The generated JSON follows the [CycloneDX 1.5 specification](https://cyclonedx.org/docs/1.5/json/). Here's an overview of the key sections:
+
+### `metadata`
+
+Contains information about the SBOM itself:
+
+- **`metadata.timestamp`** — when the SBOM was generated (ISO 8601)
+- **`metadata.tools`** — identifies VIPM CLI as the generating tool
+- **`metadata.component`** — your product: the name, version, and type set via `--product-name`, `--product-version`, and `--product-type`
+
+### `components`
+
+An array of dependencies found in your project. Each component includes:
+
+| Field | Description |
+|-------|-------------|
+| `type` | Component type (e.g., `library`) |
+| `name` | Package name |
+| `version` | Package version |
+| `purl` | Package URL — `pkg:vipm/name@version` or `pkg:nipkg/name@version` |
+| `supplier` | Package vendor or publisher |
+| `description` | Package description |
+| `licenses` | SPDX license identifiers |
+| `hashes` | SHA-256 and MD5 checksums |
+
+### `serialNumber` and `version`
+
+Each SBOM has a unique serial number (`urn:uuid:...`) and a document version (starting at 1). These support tracking multiple revisions of the same SBOM over time. You can set them explicitly with `--document-serial-number` and `--document-version`, or let the CLI auto-generate them.
+
+--8<-- "need-help.md"

--- a/docs/security/index.md
+++ b/docs/security/index.md
@@ -32,7 +32,7 @@ The [JKI Security Suite](https://jki.net/security/) provides static analysis for
 
     [Learn More about Security Tools for LabVIEW](https://jki.net/security/){ .md-button }
 
-VIPM also supports **Software Bill of Materials (SBOM)** generation for LabVIEW software, giving package publishers a machine-readable inventory of their LabVIEW software components and dependencies. SBOMs are a key requirement of the [EU Cyber Resilience Act](https://jki.net/cra/) and are increasingly expected across regulated industries. Combined with static analysis, SBOM generation gives teams visibility into both the code they write and the components they depend on.
+VIPM also supports **[Software Bill of Materials (SBOM)](../sbom/index.md)** generation for LabVIEW software, giving package publishers a machine-readable inventory of their LabVIEW software components and dependencies in [CycloneDX](https://cyclonedx.org/) format. SBOMs are a key requirement of the [EU Cyber Resilience Act](https://jki.net/cra/) and are increasingly expected across regulated industries. Combined with static analysis, SBOM generation gives teams visibility into both the code they write and the components they depend on. See the [SBOM documentation](../sbom/index.md) to get started.
 
 !!! warning "Disclaimer"
     This notice is informational and not legal advice. For authoritative information about the EU CRA regulations, please visit [european-cyber-resilience-act.com](https://www.european-cyber-resilience-act.com).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,7 +51,12 @@ plugins:
 
 nav:
   - Home: index.md
-  - VIPM 2026Q1 Preview 3: preview.md
+  - VIPM 2026 Q3 Preview 1: preview.md
+  - Security: security/index.md
+  - SBOM:
+    - sbom/index.md
+    - sbom/getting-started.md
+    - sbom/workflows.md
   - vipm.toml (Preview):
     - vipm-toml/index.md
     - vipm-toml/getting-started.md
@@ -72,9 +77,9 @@ nav:
     - linux/index.md
     - linux/ubuntu.md
     - linux/VIPM Linux Crash on Package Installation - Permission Fix.md
-  - Security: security/index.md
   - Release notes:
     - release-notes/index.md
+    - release-notes/2026.1.md
     - release-notes/2025.3.1.md
     - release-notes/2025.3.md
     - release-notes/2024.3.md


### PR DESCRIPTION
LabVIEW teams increasingly need to produce Software Bills of Materials for regulatory compliance (CRA) and supply chain transparency. This PR adds public documentation for the new `vipm sbom` and `vipm sync` CLI commands shipping in the 2026 Q3 Preview, and transitions the site from the Q1 preview cycle (now GA) to Q3.

## Summary

- Add new **SBOM** nav section with three pages: overview, getting started tutorial, and workflows guide
- Add `vipm sbom` and `vipm sync` to the **CLI Command Reference** with full options, examples, and exit codes
- Rewrite **preview page** for 2026 Q3 Preview 1 (SBOM + sync as headline features)
- Add **2026 Q1 release notes** (archives shipped Q1 preview content)
- Update **Security** page to link to SBOM docs and mention CycloneDX
- Move **Security** higher in nav (before SBOM, after Preview)

## Test plan

- [ ] `uv run mkdocs build --strict` passes with no warnings
- [ ] All cross-links between SBOM, CLI, Security, and Preview pages resolve correctly
- [ ] SBOM pages display the Q3 preview admonition snippet
- [ ] Nav structure renders correctly with new sections
- [ ] Review command reference for accuracy against `vipm sbom --help` and `vipm sync --help`

Related: #50 (follow-up to clean up stale Q1 preview snippet from GA pages)