### PR TITLE
Add SBOM docs, CLI gap fills, env vars, NIPM guide, and syntax highlighting

### DIFF
--- a/docs/.snippets/sbom-preview.md
+++ b/docs/.snippets/sbom-preview.md
@@ -1,0 +1,4 @@
+!!! info "Preview Feature — Available in VIPM 2026 Q3 Preview"
+
+    The SBOM and sync commands are available in the **[VIPM 2026 Q3 Preview](../preview.md)**.
+    Download it to try these features and share your feedback.

--- a/docs/cli/command-reference.md
+++ b/docs/cli/command-reference.md
@@ -31,6 +31,8 @@ Unless a command states otherwise, it returns exit code `0` on success and a non
 | [`vipm package-list-refresh`](#vipm-package-list-refresh) | Refresh repository metadata (legacy command, still supported). |
 | [`vipm activate`](#vipm-activate) | Activate VIPM Pro using a serial number, name, and email. |
 | [`vipm build`](#vipm-build) | Build packages from `.vipb` specs or LabVIEW project build specs. |
+| [`vipm sbom`](#vipm-sbom) | Generate a CycloneDX SBOM from a project or manifest. |
+| [`vipm sync`](#vipm-sync) | Reconcile vipm.toml from a LabVIEW project scan. |
 | [`vipm version`](#vipm-version) | Output the CLI and Desktop version numbers. |
 | [`vipm about`](#vipm-about) | Print installation details (paths, versions). |
 
@@ -284,6 +286,139 @@ Building VI Package from path/to/your_package.vipb
 - **Linux build limitations**: Review the [VIPM Preview docs](../preview.md) for current platform support notes.
 - **Missing dependencies**: Run `vipm install project.vipc` before invoking `vipm build` in CI.
 
+## `vipm sbom`
+
+--8<-- "sbom-preview.md"
+
+Generates a [CycloneDX](https://cyclonedx.org/) Software Bill of Materials (SBOM) from a project file or manifest. See the [SBOM documentation](../sbom/index.md) for a tutorial and workflow guidance.
+
+### Syntax
+
+```bash
+vipm sbom [INPUT] --format cyclonedx --schema-version 1.5 --output <PATH> [OPTIONS]
+```
+
+`INPUT` is a `vipm.toml`, `.lvproj`, `.dragon`, or `.vipc` file. If omitted, the CLI searches upward for a `vipm.toml`.
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `--format cyclonedx` | **Required.** Output format. |
+| `--schema-version 1.5` | **Required.** CycloneDX spec version for the output document. |
+| `--output <PATH>` | **Required.** File path for the generated SBOM (relative or absolute). |
+| `--product-name <NAME>` | Sets `metadata.component.name` in the SBOM. Defaults to the input filename stem. |
+| `--product-version <VERSION>` | Sets `metadata.component.version`. Omitted from the SBOM if not provided. |
+| `--product-type <TYPE>` | Sets `metadata.component.type`. One of: `application` (default), `library`, `framework`, `container`, `firmware`, `device`, `file`. |
+| `--document-version <N>` | BOM revision number (default: `1`). |
+| `--document-serial-number <URN>` | Unique BOM identifier (`urn:uuid:...`). Auto-generated if omitted. |
+| `--no-vipm` | Exclude VIPM packages from the SBOM. |
+| `--no-nipm` | Exclude NI packages (NIPM) from the SBOM. |
+| `--no-dev` | Exclude dev-dependencies (`vipm.toml` input only). |
+| `--follow-linker` | Follow the VI linker to discover subVI dependencies (`.lvproj` input only). |
+| `--follow-depth <N>` | Linker traversal depth limit. Requires `--follow-linker`. |
+
+### Examples
+
+Generate an SBOM from a LabVIEW project:
+
+```bash
+vipm sbom MyProject.lvproj \
+  --format cyclonedx \
+  --schema-version 1.5 \
+  --product-name "My Instrument" \
+  --product-version 2.1.0 \
+  --output build/bom.json
+```
+
+Generate from a vipm.toml, excluding dev-dependencies:
+
+```bash
+vipm sbom vipm.toml \
+  --format cyclonedx \
+  --schema-version 1.5 \
+  --no-dev \
+  --output build/bom.json
+```
+
+Expected output on success:
+
+```
+SBOM written to build/bom.json
+```
+
+### Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | SBOM generated successfully |
+| `1` | Unexpected or unclassified error |
+| `2` | Invalid arguments or failed input validation |
+| `4` | Requested LabVIEW version is not installed |
+| `6` | Insufficient edition, license, or activation |
+| `8` | File system or IO failure (e.g., cannot write to `--output` path) |
+| `13` | Input file is not a supported type |
+| `14` | Input file exists but is malformed |
+| `15` | A required file does not exist |
+
+Any non-zero exit code means the SBOM was **not** produced. The `--output` file is only written on exit code `0`.
+
+On failure, stderr contains a human-readable error message. Example:
+
+```
+error: No LabVIEW installation found for version '2024'.
+help: Use 'vipm labview-list' to see available versions
+```
+
+### Common Issues
+
+- **Missing required flags**: `--format`, `--schema-version`, and `--output` are always required — there are no defaults.
+- **Wrong LabVIEW version**: Use `--labview-version` and `--labview-bitness` to target the correct installation when scanning `.lvproj` files.
+- **`--no-dev` on non-toml input**: The `--no-dev` flag is only valid with `vipm.toml` input.
+
+## `vipm sync`
+
+--8<-- "sbom-preview.md"
+
+Reconciles a `vipm.toml` manifest from the dependencies discovered in a LabVIEW project scan.
+
+### Syntax
+
+```bash
+vipm sync [TARGET] --from <SOURCE> [OPTIONS]
+```
+
+`TARGET` is the `vipm.toml` to update. If omitted, the CLI searches upward from the current directory. `SOURCE` is the file to scan (e.g., a `.lvproj`).
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `--from <SOURCE>` | **Required.** The source file to scan for dependencies. |
+| `--dry-run` | Preview changes without writing to the manifest. |
+| `--no-vipm` | Exclude VIPM packages from the sync. |
+| `--no-nipm` | Exclude NI packages (NIPM) from the sync. |
+| `--follow-linker` | Follow the VI linker to discover subVI dependencies. |
+| `--follow-depth <N>` | Linker traversal depth limit. Requires `--follow-linker`. |
+
+### Examples
+
+Sync vipm.toml from a LabVIEW project:
+
+```bash
+vipm sync --from MyProject.lvproj
+```
+
+Preview changes without writing:
+
+```bash
+vipm sync --from MyProject.lvproj --dry-run
+```
+
+### Common Issues
+
+- **No vipm.toml found**: Either specify the target path explicitly or run the command from a directory that contains (or is a child of a directory that contains) a `vipm.toml`.
+
 ## `vipm version`
 
 Prints the VIPM CLI and Desktop versions. Useful for support tickets and automation logs.
@@ -312,6 +447,7 @@ Use `vipm about --help` to review the latest options.
 ## Related Resources
 
 - [Getting Started](getting-started.md)
+- [SBOM Generation](../sbom/index.md)
 - [Docker and Containers](docker.md)
 - [GitHub Actions and CI/CD](github-actions.md)
 - Project plan: `dev-docs/cli-docs-improvement-proposal.md`

--- a/docs/cli/command-reference.md
+++ b/docs/cli/command-reference.md
@@ -5,7 +5,7 @@ title: Command Reference
 Use this page to look up syntax, options, and common workflows for the most frequently used VIPM CLI commands. For additional details, remember that `vipm help` lists every command and `vipm <command> --help` prints the authoritative help text for a single command.
 
 !!! info "vipm.toml Commands (Preview)"
-    Looking for `vipm init`, `vipm add`, `vipm remove`, `vipm lock`, or `vipm clean`? These commands work with the new `vipm.toml` project configuration format. See the [vipm.toml Getting Started guide](../vipm-toml/getting-started.md) for details.
+    Looking for `vipm init`, `vipm add`, `vipm remove`, `vipm lock`, or `vipm clean`? These commands work with the new `vipm.toml` project configuration format. See the [vipm.toml Getting Started guide](../vipm-toml/getting-started.md) for details. For managing NI packages (NIPM) in vipm.toml, see [NI Packages (NIPM)](../vipm-toml/nipm.md).
 
 ## Global Options
 
@@ -17,6 +17,9 @@ These flags are available on every command unless noted otherwise:
 | `--labview-version <YYYY>` | Targets a specific LabVIEW year (e.g., `2025`). Combine with `--labview-bitness` when multiple bitnesses exist. |
 | `--labview-bitness <32|64>` | Specifies 32-bit or 64-bit LabVIEW when both are installed for the same year. Only meaningful with `--labview-version`. |
 | `--color-mode <auto|always|never>` | Controls CLI color output (defaults to `auto`). |
+| `--timeout <seconds>` | How long to wait for the operation to finish. Use `-1` for no timeout. |
+| `--show-progress` | Display a progress indicator during long-running operations. |
+| `--verbose`, `-v` | Enable verbose output for additional diagnostic detail. |
 | `-h`, `--help` | Shows help for the current command. |
 
 Unless a command states otherwise, it returns exit code `0` on success and a non-zero value on failure (check your automation scripts for non-zero exits).
@@ -28,6 +31,7 @@ Unless a command states otherwise, it returns exit code `0` on success and a non
 | [`vipm install`](#vipm-install) | Install packages, `.vipc`, `.vip`, `.ogp`, or `.dragon` files. |
 | [`vipm uninstall`](#vipm-uninstall) | Remove packages from the selected LabVIEW installation. |
 | [`vipm list`](#vipm-list) | List installed packages or inspect a `.vipc`/`.dragon` file. |
+| [`vipm info`](#vipm-info) | Show metadata and installed files for a package. |
 | [`vipm package-list-refresh`](#vipm-package-list-refresh) | Refresh repository metadata (legacy command, still supported). |
 | [`vipm activate`](#vipm-activate) | Activate VIPM Pro using a serial number, name, and email. |
 | [`vipm build`](#vipm-build) | Build packages from `.vipb` specs or LabVIEW project build specs. |
@@ -51,6 +55,9 @@ vipm install [OPTIONS] <package|path>...
 | Option | Description |
 |--------|-------------|
 | `--upgrade` | If the package is already installed, upgrade it to the latest available version. |
+| `--dev` | Install dev-dependencies from `vipm.toml`. |
+| `--no-dev` | Exclude dev-dependencies when installing from `vipm.toml`. |
+| `--yes`, `-y` | Skip confirmation prompts and proceed automatically. |
 
 ### Examples
 
@@ -91,8 +98,15 @@ Removes packages from the selected LabVIEW installation.
 ### Syntax
 
 ```bash
-vipm uninstall <package|package@version>...
+vipm uninstall [OPTIONS] <package|package@version>...
 ```
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `--allow-version-mismatch`, `-F`, `--force` | Proceed even if the installed version does not match the requested version. |
+| `--yes`, `-y` | Skip confirmation prompts and proceed automatically. |
 
 ### Examples
 
@@ -127,6 +141,8 @@ vipm list [OPTIONS] [path/to/project.vipc]
 | Option | Description |
 |--------|-------------|
 | `--installed` | Show every package installed in the active LabVIEW version. |
+| `--dev` | Include dev-dependencies when listing from `vipm.toml`. |
+| `--no-dev` | Exclude dev-dependencies when listing from `vipm.toml`. |
 
 ### Examples
 
@@ -148,6 +164,43 @@ Expected output:
 Listing installed packages
 Found 4 packages:
   OpenG Boolean Library (oglib_boolean v6.0.0.9)
+```
+
+## `vipm info`
+
+Shows metadata for a package, including name, version, description, vendor, and license. Can also list installed files. For managing NI packages in vipm.toml, see [NI Packages (NIPM)](../vipm-toml/nipm.md).
+
+### Syntax
+
+```bash
+vipm info [OPTIONS] <package>
+```
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `--nipm` | Look up an NI package (NIPM) instead of a VIPM package. |
+| `--installed-files` | List all files installed by the package (Professional edition). |
+
+### Examples
+
+Show metadata for a VIPM package:
+
+```bash
+vipm info oglib_boolean
+```
+
+Show metadata for an NI package:
+
+```bash
+vipm info --nipm ni-labview-2025-core --labview-version 2025
+```
+
+List installed files for a package:
+
+```bash
+vipm info oglib_boolean --installed-files
 ```
 
 ## `vipm search`
@@ -273,6 +326,12 @@ vipm build \
 |--------|-------------|
 | `--lvproj-spec <name>` | Name of the LabVIEW project build spec to run when using `.lvproj`. |
 | `--lvproj-target <name>` | LabVIEW project target (defaults to `My Computer`). |
+| `--all` | Build all build specs found in the project. |
+| `--version-number <VERSION>` | Override the version number for the build. |
+| `--build-number <N>` | Override the build number for the build. |
+| `--debug` | Build in debug mode. |
+| `--no-deps` | Skip installing dependencies before building. |
+| `--rebuild-deps` | Reinstall dependencies before building, even if already installed. |
 
 ### Example Output
 
@@ -447,6 +506,7 @@ Use `vipm about --help` to review the latest options.
 ## Related Resources
 
 - [Getting Started](getting-started.md)
+- [Environment Variables](environment-variables.md)
 - [SBOM Generation](../sbom/index.md)
 - [Docker and Containers](docker.md)
 - [GitHub Actions and CI/CD](github-actions.md)

--- a/docs/cli/docker.md
+++ b/docs/cli/docker.md
@@ -43,7 +43,7 @@ A typical Docker setup for VIPM includes:
 
 Example `.env` file:
 
-```bash
+```env
 # VIPM Pro activation credentials
 VIPM_SERIAL_NUMBER=your-serial-number-here
 VIPM_FULL_NAME=Your Full Name

--- a/docs/cli/docker.md
+++ b/docs/cli/docker.md
@@ -43,7 +43,7 @@ A typical Docker setup for VIPM includes:
 
 Example `.env` file:
 
-```env
+```bash
 # VIPM Pro activation credentials
 VIPM_SERIAL_NUMBER=your-serial-number-here
 VIPM_FULL_NAME=Your Full Name

--- a/docs/cli/docker.md
+++ b/docs/cli/docker.md
@@ -44,10 +44,23 @@ A typical Docker setup for VIPM includes:
 Example `.env` file:
 
 ```bash
+# VIPM Pro activation credentials
 VIPM_SERIAL_NUMBER=your-serial-number-here
 VIPM_FULL_NAME=Your Full Name
 VIPM_EMAIL=your.email@example.com
+
+# Auto-confirm prompts (recommended for CI/CD)
+VIPM_ASSUME_YES=1
+
+# Disable colored output for cleaner CI logs
+NO_COLOR=1
+
+# Set CI=true if running Docker outside a CI system (e.g. local testing)
+# to get longer default timeouts. Most CI runners set this automatically.
+# CI=true
 ```
+
+See [Environment Variables](environment-variables.md) for the full list and [GitHub Actions and CI/CD](github-actions.md) for workflow examples.
 
 ### Running the Container
 

--- a/docs/cli/docker.md
+++ b/docs/cli/docker.md
@@ -76,8 +76,8 @@ Once inside a running container, use the same CLI commands described in the [CLI
 - **Install packages or `.vipc` files`** just like on desktop. If you have multiple LabVIEW versions in the container image, pair your command with `--labview-version` (and `--labview-bitness` when needed).
 
   ```bash
-  vipm install oglib_boolean
-  vipm install project.vipc
+  vipm install -y oglib_boolean
+  vipm install -y project.vipc
   ```
 
 - **List/verify installations** to confirm the container state before running builds or tests:
@@ -88,6 +88,9 @@ Once inside a running container, use the same CLI commands described in the [CLI
   ```
 
 > 💡 Because containers are often ephemeral, script these commands in your Docker entrypoint or CI workflow so every run activates, refreshes, installs, and verifies automatically.
+
+!!! tip "Skip prompts in CI"
+    Set `VIPM_ASSUME_YES=1` in your container environment to auto-confirm all prompts, or use the `-y` flag on individual commands. See [Environment Variables](environment-variables.md) for details.
 
 ## Building VI Packages in Containers
 

--- a/docs/cli/environment-variables.md
+++ b/docs/cli/environment-variables.md
@@ -1,0 +1,113 @@
+---
+title: Environment Variables
+---
+
+# Environment Variables
+
+The VIPM CLI recognizes several environment variables that control its behavior. These are useful for CI/CD pipelines, automation scripts, and troubleshooting.
+
+## CI Environment Detection
+
+VIPM automatically detects CI environments and adjusts its behavior — for example, using longer default timeouts to account for slower CI runners. The following CI systems are detected automatically:
+
+| Variable | CI System |
+|----------|-----------|
+| `CI` | Generic CI convention |
+| `CONTINUOUS_INTEGRATION` | Generic CI convention |
+| `GITHUB_ACTIONS` | GitHub Actions |
+| `GITLAB_CI` | GitLab CI |
+| `JENKINS_URL` | Jenkins |
+| `TRAVIS` | Travis CI |
+| `CIRCLECI` | CircleCI |
+| `BUILDKITE` | Buildkite |
+| `DRONE` | Drone |
+| `APPVEYOR` | AppVeyor |
+| `TF_BUILD` | Azure DevOps |
+| `TEAMCITY_VERSION` | TeamCity |
+
+No configuration is needed — if any of these variables are set, VIPM treats the environment as CI.
+
+!!! note
+    CI detection affects **timeouts only**. It does not automatically skip confirmation prompts. Use `VIPM_ASSUME_YES` or the `--yes` flag to skip prompts in CI. See [Confirmation Prompts](#confirmation-prompts) below.
+
+## Confirmation Prompts
+
+### `VIPM_ASSUME_YES`
+
+Auto-confirms all interactive prompts without requiring the `--yes` / `-y` flag on each command. This is the recommended approach for CI/CD pipelines where you want all commands to proceed non-interactively.
+
+```bash
+export VIPM_ASSUME_YES=1
+vipm install project.vipc     # no prompt
+vipm uninstall oglib_boolean  # no prompt
+```
+
+| Value | Behavior |
+|-------|----------|
+| `1`, `true`, `yes` (any truthy value) | Auto-confirm all prompts |
+| `0`, `false` | Disabled (prompts as normal) |
+| Empty string | Disabled (a warning is logged) |
+
+Alternatively, use the `--yes` / `-y` flag on individual commands:
+
+```bash
+vipm install -y project.vipc
+```
+
+## Timeouts
+
+### `VIPM_TIMEOUT`
+
+Overrides the default operation timeout (in seconds). When set, this takes precedence over the `--timeout` flag and any CI-adjusted defaults.
+
+```bash
+export VIPM_TIMEOUT=300   # 5 minutes
+vipm install project.vipc
+```
+
+## Debugging
+
+### `VIPM_DEBUG`
+
+Enables verbose debug output for troubleshooting.
+
+```bash
+export VIPM_DEBUG=1
+vipm install oglib_boolean
+```
+
+## Output
+
+### `NO_COLOR`
+
+Disables colored output, following the [no-color.org](https://no-color.org/) standard. Equivalent to `--color-mode never`.
+
+```bash
+export NO_COLOR=1
+```
+
+### `SOURCE_DATE_EPOCH`
+
+When set, VIPM uses this Unix timestamp for the `generated_at` field in `--json` output instead of the current time. This supports [reproducible builds](https://reproducible-builds.org/specs/source-date-epoch/).
+
+```bash
+export SOURCE_DATE_EPOCH=1710000000
+```
+
+## Edition
+
+### `VIPM_COMMUNITY_EDITION`
+
+Forces VIPM to operate in Community Edition mode, regardless of activation status.
+
+```bash
+export VIPM_COMMUNITY_EDITION=1
+```
+
+## Related Resources
+
+- [CLI Command Reference](command-reference.md) — command flags and options
+- [Docker and Containers](docker.md) — container-specific environment setup
+- [GitHub Actions and CI/CD](github-actions.md) — CI workflow examples
+
+--8<-- "need-help.md"

--- a/docs/cli/github-actions.md
+++ b/docs/cli/github-actions.md
@@ -40,6 +40,9 @@ Store your VIPM Pro credentials as GitHub repository secrets:
 
 You can find your VIPM Pro serial number on the [VIPM account page](https://www.vipm.io/account/).
 
+!!! tip "Skip prompts in CI"
+    Use the `-y` flag on install/uninstall commands, or set `VIPM_ASSUME_YES=1` as an environment variable to auto-confirm all prompts across your workflow. See [Environment Variables](environment-variables.md) for details.
+
 ### Basic Workflow Example
 
 Create a file at `.github/workflows/vipm-ci.yml`:
@@ -81,7 +84,7 @@ jobs:
         run: vipm package-list-refresh
       
       - name: Install project dependencies
-        run: vipm install project.vipc
+        run: vipm install -y project.vipc
       
       - name: List installed packages
         run: vipm list --installed
@@ -94,7 +97,7 @@ To install specific packages instead of using a `.vipc` file:
 ```yaml
 - name: Install required packages
   run: |
-    vipm install \
+    vipm install -y \
       oglib_boolean \
       oglib_numeric \
       jki_lib_state_machine
@@ -165,7 +168,7 @@ jobs:
         run: vipm package-list-refresh
       
       - name: Install dependencies
-        run: vipm install project.vipc
+        run: vipm install -y project.vipc
       
       - name: Build project
         run: |

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -4,7 +4,7 @@ title: Overview
 
 --8<-- "preview-available.md"
 
-VIPM includes a powerful command-line interface (CLI) that enables automation, integration with CI/CD pipelines, and usage in containerized environments.
+VIPM includes a powerful command-line interface (CLI) that enables automation, integration with CI/CD pipelines, and usage in containerized environments. The CLI also supports [SBOM generation](../sbom/index.md) for producing CycloneDX software inventories of your LabVIEW projects.
 
 ## Example Commands
 

--- a/docs/preview.md
+++ b/docs/preview.md
@@ -1,6 +1,4 @@
-# VIPM 2026Q1 Preview 3
-
-Watch our [overview video](https://www.youtube.com/watch?v=2vHFfQF0agc) to see the new features and improvements in this preview release.
+# VIPM 2026 Q3 Preview 1
 
 ## Installation & Feedback
 
@@ -26,85 +24,37 @@ Report issues on [GitHub](https://github.com/vipm-io/vipm-desktop-issues/issues)
 
 ## What's New
 
-### Updates in Preview 3
-This release focuses on polish and bug fixes based on community feedback:
+### CycloneDX SBOM Generation
 
-**VIPM Desktop Improvements:**
+Generate a [CycloneDX](https://cyclonedx.org/) 1.5 Software Bill of Materials (SBOM) for your LabVIEW project with a single command. The SBOM includes VIPM packages, NI packages (NIPM), enriched metadata (licenses, descriptions, vendors), and cryptographic hashes (SHA-256, MD5).
 
-- **Fixed "Search Online" button alignment**: Corrected alignment of the "Search Online" button in the window that appears when no packages are available for search results
-- **Fixed destination deletion text issue**: Resolved issue where deleting a custom VI Package Builder destination would leave previously selected text white
-- **Improved installer window behavior**: The Updates Installer window now stays visible instead of hiding to the System Tray, making installation progress clearly visible
+SBOMs are increasingly required for regulatory compliance, including the [EU Cyber Resilience Act (CRA)](https://jki.net/cra/). See the [SBOM documentation](sbom/index.md) for details.
 
-**VIPM CLI Improvements:**
+```bash
+vipm sbom MyProject.lvproj \
+  --format cyclonedx \
+  --schema-version 1.5 \
+  --product-name "My Instrument" \
+  --product-version 2.1.0 \
+  --output build/bom.json
+```
 
-- **Fixed `vipm about` initialization error**: The `vipm about` command now prints all fields and outputs a warning when VIPM Desktop is not fully initialized (such as on first startup)
-- **Added Global Options to command help**: Running `--help` for individual commands (e.g., `vipm build --help`) now displays Global Options in addition to command-specific options
-- **Fixed LabVIEW version reporting**: The `vipm build LVPROJ_FILE` command now correctly reports the LabVIEW version being used
-- **Fixed output line formatting**: Resolved issue where `vipm build LVPROJ_FILE` output would sometimes garble multiple lines together into a single line
+**[Get started with SBOM generation →](sbom/getting-started.md)**
 
-### Updates in Preview 2
+### Manifest Sync (vipm sync)
 
-- **VI Package building officially supported on Linux**: Build .vip packages natively on Linux systems
-- **Multi-platform .vipb files**: Package build files (.vipb) now work seamlessly across Windows and Linux
-- **Improved Linux support for RHEL**: Native RPM packages for Red Hat Enterprise Linux and derivatives
-- **Fixed .dragon and .vip installation**: Resolved issues with VIPM CLI when installing .dragon and .vip files
-- **Case-insensitive library name handling**: VIPM now handles internal library name changes in a case-insensitive manner
-- **LabVIEW Class default menu support**: Re-added support for LabVIEW Class default menu items
+Keep your `vipm.toml` manifest in sync with the dependencies discovered in a LabVIEW project:
 
-### LabVIEW 2026 Support
-This preview release has been tested with LabVIEW 2026 Beta and includes full LabVIEW 2026 support. You can access the LabVIEW 2026 Beta at the [LabVIEW Beta forum](https://forums.ni.com/t5/LabVIEW-Beta/ct-p/7035).
+```bash
+vipm sync --from MyProject.lvproj
+```
 
-### Improved Support for Installing VIPM on Linux
-
-VIPM is now available as native Linux packages for seamless installation and updates:
-
-- **DEB Packages** - Native support for Debian-based distributions (Ubuntu, Debian, Linux Mint, and derivatives)
-
-- **RPM Packages** - Native support for Red Hat-based distributions (RHEL, Fedora, CentOS, Rocky Linux, and derivatives)
-
-### VIPM Command Line Interface (CLI)
-
-The new VIPM CLI brings powerful automation capabilities to your package management workflows. Install, update, and remove packages from the command line, integrate VIPM operations into build scripts and CI/CD pipelines, and automate package management tasks across multiple systems.
-
-Once installed, try out VIPM CLI by opening a terminal and typing `vipm`.
-
-### vipm.toml Project Configuration (Preview Feature)
-
-Manage your LabVIEW project's dependencies and builds with a modern, human-readable `vipm.toml` configuration file. Features include declarative dependency management, reproducible builds via lock files, and seamless CI/CD integration.
-
-**[Get started with vipm.toml →](vipm-toml/getting-started.md)**
-
-### Faster Downloads and Improved Stability (Preview Feature)
-
-VIPM now uses a modernized HTTP client for improved package repository communication and download performance. This preview feature lays the groundwork for enhanced reliability and future capabilities.
-
-### Bug Fixes and Usability Improvements
-Various bug and usability fixes including:
-
-* LabVIEW Libraries (lvlib) that contain support files now correctly point to the correct location. Thank you to GitHub users @NatanBiesmans and @AlexanderElbert for reporting this issue.
-* Improved Linux workflows. Thank you to GitHub users @pesmith8a and @JamesMc86 for reporting this issue.
-* Fixed issue where similar VIPB destination names become linked. Thank you to GitHub user @qalldredge for reporting this issue.
-* "Place folder contents in destination" now works for support files. Thank you to GitHub user @Sdusing7 for reporting this issue.
-
-  > This is a preview feature. Enable this through Options > Preview Features and select "[Bug Fix] Place Folder Contents for Non-LabVIEW Files".
-
---8<-- "need-help.md"    
+Preview changes before writing with `--dry-run`. See the [CLI Command Reference](cli/command-reference.md#vipm-sync) for full options.
 
 ---
 
-## Thank You to Our Community
+## Feedback
 
-Thank you to everyone who has been testing the VIPM 2026Q1 Preview! Your feedback and testing efforts are invaluable in helping us improve the product.
+Thank you to everyone testing VIPM previews! Your feedback is invaluable in helping us improve the product.
 
-Please continue to report any issues you encounter:
-
-**Feedback**
 Report issues on [GitHub](https://github.com/vipm-io/vipm-desktop-issues/issues) or join us on [Discord](https://discord.gg/GCB7QQyzsP)
-
-We appreciate your ongoing support and contributions to making VIPM better for the entire LabVIEW community!
-
----
-
-**Page last edited:** November 19, 2025
-
----

--- a/docs/release-notes/2026.1.md
+++ b/docs/release-notes/2026.1.md
@@ -1,0 +1,47 @@
+---
+title: VIPM 2026 Q1 - Release Notes
+---
+
+# VIPM 2026 Q1
+
+VIPM 2026 Q1 introduces the VIPM Command Line Interface (CLI), native Linux packages, LabVIEW 2026 support, and the vipm.toml project configuration format.
+
+## VIPM Command Line Interface (CLI)
+
+A new CLI brings automation capabilities to LabVIEW package management. Install, update, and remove packages from the command line, integrate VIPM into build scripts and CI/CD pipelines, and automate package management across multiple systems.
+
+The CLI ships with every edition of VIPM Desktop. See the [CLI documentation](../cli/index.md) to get started.
+
+## vipm.toml Project Configuration (Preview)
+
+Manage your LabVIEW project's dependencies and builds with a human-readable `vipm.toml` configuration file. Features include declarative dependency management, reproducible builds via lock files, and CI/CD integration.
+
+See [vipm.toml Getting Started](../vipm-toml/getting-started.md) for details.
+
+## Native Linux Packages
+
+VIPM is now available as native Linux packages:
+
+- **DEB packages** for Debian-based distributions (Ubuntu, Debian, Linux Mint, and derivatives)
+- **RPM packages** for Red Hat-based distributions (RHEL, Fedora, CentOS, Rocky Linux, and derivatives)
+
+VI Package building is officially supported on Linux, and `.vipb` build files work across Windows and Linux.
+
+## LabVIEW 2026 Support
+
+Full support for LabVIEW 2026.
+
+## Additional improvements
+
+- Faster package downloads via modernized HTTP client
+- Multi-platform `.vipb` files work across Windows and Linux
+- LabVIEW Libraries (lvlib) with support files now point to the correct location
+- Fixed issue where similar VIPB destination names became linked
+- "Place folder contents in destination" now works for support files
+- LabVIEW Class default menu support re-added
+- Case-insensitive library name handling for internal library name changes
+- `vipm about` now prints all fields with a warning when VIPM Desktop is not fully initialized
+- `vipm build` correctly reports the LabVIEW version being used
+- Global options now display in individual command `--help` output
+
+--8<-- "need-help.md"

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -8,6 +8,7 @@ Please select a release from the navbar on the left or choose from one of the it
 
 ## Recent Releases
 
+- [VIPM 2026 Q1](2026.1.md)
 - [VIPM 2025Q3 fix 1 for Windows](2025.3.1.md)
 
 ## Past Releases

--- a/docs/sbom/getting-started.md
+++ b/docs/sbom/getting-started.md
@@ -1,0 +1,104 @@
+---
+title: Getting Started
+---
+
+# Getting Started with SBOM Generation
+
+--8<-- "sbom-preview.md"
+
+This guide walks you through generating your first CycloneDX SBOM with the VIPM CLI.
+
+## Step 1 — Verify the CLI is available
+
+Open a terminal and confirm that VIPM is installed:
+
+```bash
+vipm --version
+```
+
+Expected output:
+
+```
+VIPM CLI version 2026.3.x
+```
+
+If the command is not found, install the [VIPM 2026 Q3 Preview](../preview.md) first.
+
+## Step 2 — Generate an SBOM
+
+Run the `vipm sbom` command against your project. This example uses a `.lvproj` file:
+
+```bash
+vipm sbom "C:\MyProject\MyProject.lvproj" ^
+  --format cyclonedx ^
+  --schema-version 1.5 ^
+  --output "C:\MyProject\build\bom.json"
+```
+
+On Linux or macOS, use backslash line continuations instead:
+
+```bash
+vipm sbom /home/user/MyProject/MyProject.lvproj \
+  --format cyclonedx \
+  --schema-version 1.5 \
+  --output /home/user/MyProject/build/bom.json
+```
+
+Expected output:
+
+```
+SBOM written to C:\MyProject\build\bom.json
+```
+
+The three required flags are `--format`, `--schema-version`, and `--output`. There are no defaults for these — they must always be specified.
+
+## Step 3 — Inspect the output
+
+Open `bom.json` to see the generated CycloneDX document. Key sections include:
+
+- **`metadata.component`** — your product (name, version, type)
+- **`metadata.tools`** — records that VIPM CLI generated the SBOM
+- **`components`** — the list of dependencies, each with a package URL (`purl`), license, vendor, description, and hashes
+
+## Step 4 — Add product metadata
+
+Set your product's name and version so they appear in the SBOM's root component:
+
+```bash
+vipm sbom MyProject.lvproj ^
+  --format cyclonedx ^
+  --schema-version 1.5 ^
+  --product-name "My Instrument" ^
+  --product-version 2.1.0 ^
+  --output build/bom.json
+```
+
+If `--product-name` is omitted, it defaults to the input filename stem (e.g., `MyProject`). If `--product-version` is omitted, the version field is left out of the SBOM.
+
+## Step 5 — Filter dependencies
+
+You can exclude specific dependency sources:
+
+```bash
+# Exclude NI packages, only include VIPM packages
+vipm sbom MyProject.lvproj ^
+  --format cyclonedx ^
+  --schema-version 1.5 ^
+  --no-nipm ^
+  --output build/bom.json
+```
+
+Available filters:
+
+| Flag | Effect |
+|------|--------|
+| `--no-vipm` | Exclude VIPM packages from the SBOM |
+| `--no-nipm` | Exclude NI packages (NIPM) from the SBOM |
+| `--no-dev` | Exclude dev-dependencies (vipm.toml input only) |
+
+## Next steps
+
+- **[Workflows](workflows.md)** — learn about different input types, CI/CD integration, and understanding the CycloneDX output
+- **[CLI Command Reference](../cli/command-reference.md#vipm-sbom)** — full parameter reference including exit codes
+
+--8<-- "need-help.md"

--- a/docs/sbom/index.md
+++ b/docs/sbom/index.md
@@ -1,0 +1,54 @@
+---
+title: SBOM Overview
+---
+
+# Software Bill of Materials (SBOM)
+
+--8<-- "sbom-preview.md"
+
+A Software Bill of Materials (SBOM) is a machine-readable inventory of every software component in your product — including package names, versions, suppliers, licenses, and cryptographic hashes. SBOMs give you and your customers visibility into exactly what ships in your software.
+
+## Why SBOMs matter
+
+Regulations such as the [EU Cyber Resilience Act (CRA)](https://jki.net/cra/) and [US Executive Order 14028](https://www.nist.gov/itl/executive-order-14028-improving-nations-cybersecurity) are making SBOMs a requirement for software products in regulated markets. Beyond compliance, SBOMs support practical goals like license auditing, vulnerability tracking, and supply chain transparency.
+
+## What VIPM generates
+
+The VIPM CLI generates [CycloneDX](https://cyclonedx.org/) 1.5 SBOMs in JSON format. A single command scans your LabVIEW project and produces an SBOM that includes:
+
+- **VIPM packages** — packages installed via VI Package Manager
+- **NI packages (NIPM)** — packages installed via NI Package Manager
+- **Enriched metadata** — display names, descriptions, vendors, license identifiers, and download URLs
+- **Cryptographic hashes** — SHA-256 and MD5 checksums for each component
+- **Product metadata** — your application's name, version, and component type
+
+## Supported inputs
+
+| Input type | Description | LabVIEW required? |
+|------------|-------------|-------------------|
+| `vipm.toml` | Project manifest with declared dependencies | No |
+| `.lvproj` | LabVIEW project file — scans installed packages directly | Yes |
+| `.dragon` | Dragon configuration file | No |
+| `.vipc` | VIPM configuration file | No |
+
+Choose the input that matches your workflow. If your project already uses `vipm.toml`, that's the simplest path — no LabVIEW installation is needed. For existing LabVIEW projects, point directly at your `.lvproj` file. See [Workflows](workflows.md) for guidance on each approach.
+
+## Prerequisites
+
+- **VIPM 2026 Q3 Preview** or later — [download here](../preview.md)
+- **LabVIEW** — required only when generating SBOMs from `.lvproj` files
+- **NI Package Manager** — required only when including NI packages in the SBOM
+
+Verify your CLI is available:
+
+```bash
+vipm --version
+```
+
+## Next steps
+
+- **[Getting Started](getting-started.md)** — generate your first SBOM in a few minutes
+- **[Workflows](workflows.md)** — choose the right approach for your project and environment
+- **[CLI Command Reference](../cli/command-reference.md#vipm-sbom)** — full parameter reference for `vipm sbom`
+
+--8<-- "need-help.md"

--- a/docs/sbom/workflows.md
+++ b/docs/sbom/workflows.md
@@ -1,0 +1,188 @@
+---
+title: Workflows
+---
+
+# SBOM Workflows
+
+--8<-- "sbom-preview.md"
+
+The VIPM CLI supports several input types for SBOM generation. This page helps you choose the right approach for your project and shows how to integrate SBOM generation into CI/CD pipelines.
+
+## Manifest-based generation (vipm.toml)
+
+If your project uses a `vipm.toml` file to declare dependencies, this is the simplest workflow. No LabVIEW installation is needed — the CLI reads the manifest directly.
+
+```bash
+vipm sbom vipm.toml \
+  --format cyclonedx \
+  --schema-version 1.5 \
+  --product-name "My Application" \
+  --product-version 1.0.0 \
+  --output build/bom.json
+```
+
+If you omit the input path, the CLI searches upward from the current directory for a `vipm.toml` file.
+
+### Excluding dev-dependencies
+
+Use `--no-dev` to omit dependencies marked as dev-only in your `vipm.toml`:
+
+```bash
+vipm sbom vipm.toml \
+  --format cyclonedx \
+  --schema-version 1.5 \
+  --no-dev \
+  --output build/bom.json
+```
+
+`--no-dev` is only available with `vipm.toml` input.
+
+### Keeping vipm.toml in sync with your project
+
+Use `vipm sync` to reconcile your `vipm.toml` with the dependencies discovered in a LabVIEW project:
+
+```bash
+vipm sync --from MyProject.lvproj
+```
+
+This updates the `vipm.toml` in your project directory to reflect the packages found in the `.lvproj` file. You can then generate SBOMs from the manifest without needing LabVIEW on your build machine.
+
+Preview changes without writing:
+
+```bash
+vipm sync --from MyProject.lvproj --dry-run
+```
+
+See the [CLI Command Reference](../cli/command-reference.md#vipm-sync) for full `vipm sync` options.
+
+## Project-based generation (.lvproj)
+
+For LabVIEW projects that don't yet use `vipm.toml`, point directly at the `.lvproj` file. The CLI scans the LabVIEW installation to discover installed packages.
+
+```bash
+vipm sbom MyProject.lvproj \
+  --format cyclonedx \
+  --schema-version 1.5 \
+  --output build/bom.json
+```
+
+### Targeting a specific LabVIEW version
+
+If multiple LabVIEW versions are installed, use the global options to select one:
+
+```bash
+vipm sbom MyProject.lvproj \
+  --labview-version 2025 \
+  --labview-bitness 64 \
+  --format cyclonedx \
+  --schema-version 1.5 \
+  --output build/bom.json
+```
+
+### Following the VI linker
+
+For deeper dependency discovery, use `--follow-linker` to trace subVI dependencies through the LabVIEW linker:
+
+```bash
+vipm sbom MyProject.lvproj \
+  --format cyclonedx \
+  --schema-version 1.5 \
+  --follow-linker \
+  --follow-depth 3 \
+  --output build/bom.json
+```
+
+`--follow-depth` sets how many levels deep the linker traversal goes. It requires `--follow-linker` to be set.
+
+## Legacy inputs (.dragon, .vipc)
+
+The CLI also accepts `.dragon` and `.vipc` files as input. These are useful when migrating from older VIPM workflows:
+
+```bash
+vipm sbom project.dragon \
+  --format cyclonedx \
+  --schema-version 1.5 \
+  --output build/bom.json
+```
+
+```bash
+vipm sbom project.vipc \
+  --format cyclonedx \
+  --schema-version 1.5 \
+  --output build/bom.json
+```
+
+## CI/CD integration
+
+SBOM generation fits naturally into build pipelines. The CLI runs headless with no GUI, making it suitable for automated environments.
+
+### Docker
+
+If you already run VIPM in Docker (see [Docker and Containers](../cli/docker.md)), add the `vipm sbom` step after your build:
+
+```bash
+vipm sbom vipm.toml \
+  --format cyclonedx \
+  --schema-version 1.5 \
+  --product-name "$PRODUCT_NAME" \
+  --product-version "$VERSION" \
+  --output /output/bom.json
+```
+
+### GitHub Actions
+
+Add an SBOM generation step to your workflow (see [GitHub Actions and CI/CD](../cli/github-actions.md) for environment setup):
+
+```yaml
+- name: Generate SBOM
+  run: |
+    vipm sbom vipm.toml \
+      --format cyclonedx \
+      --schema-version 1.5 \
+      --product-name "${{ github.event.repository.name }}" \
+      --product-version "${{ github.ref_name }}" \
+      --output build/bom.json
+
+- name: Upload SBOM artifact
+  uses: actions/upload-artifact@v4
+  with:
+    name: sbom
+    path: build/bom.json
+```
+
+### Verifying success in automation
+
+Check the exit code to determine success. Exit code `0` means the SBOM was written; any non-zero code means it was not produced. See the [exit codes table](../cli/command-reference.md#vipm-sbom) for the full list.
+
+## Understanding the CycloneDX output
+
+The generated JSON follows the [CycloneDX 1.5 specification](https://cyclonedx.org/docs/1.5/json/). Here's an overview of the key sections:
+
+### `metadata`
+
+Contains information about the SBOM itself:
+
+- **`metadata.timestamp`** — when the SBOM was generated (ISO 8601)
+- **`metadata.tools`** — identifies VIPM CLI as the generating tool
+- **`metadata.component`** — your product: the name, version, and type set via `--product-name`, `--product-version`, and `--product-type`
+
+### `components`
+
+An array of dependencies found in your project. Each component includes:
+
+| Field | Description |
+|-------|-------------|
+| `type` | Component type (e.g., `library`) |
+| `name` | Package name |
+| `version` | Package version |
+| `purl` | Package URL — `pkg:vipm/name@version` or `pkg:nipkg/name@version` |
+| `supplier` | Package vendor or publisher |
+| `description` | Package description |
+| `licenses` | SPDX license identifiers |
+| `hashes` | SHA-256 and MD5 checksums |
+
+### `serialNumber` and `version`
+
+Each SBOM has a unique serial number (`urn:uuid:...`) and a document version (starting at 1). These support tracking multiple revisions of the same SBOM over time. You can set them explicitly with `--document-serial-number` and `--document-version`, or let the CLI auto-generate them.
+
+--8<-- "need-help.md"

--- a/docs/security/index.md
+++ b/docs/security/index.md
@@ -32,7 +32,7 @@ The [JKI Security Suite](https://jki.net/security/) provides static analysis for
 
     [Learn More about Security Tools for LabVIEW](https://jki.net/security/){ .md-button }
 
-VIPM also supports **Software Bill of Materials (SBOM)** generation for LabVIEW software, giving package publishers a machine-readable inventory of their LabVIEW software components and dependencies. SBOMs are a key requirement of the [EU Cyber Resilience Act](https://jki.net/cra/) and are increasingly expected across regulated industries. Combined with static analysis, SBOM generation gives teams visibility into both the code they write and the components they depend on.
+VIPM also supports **[Software Bill of Materials (SBOM)](../sbom/index.md)** generation for LabVIEW software, giving package publishers a machine-readable inventory of their LabVIEW software components and dependencies in [CycloneDX](https://cyclonedx.org/) format. SBOMs are a key requirement of the [EU Cyber Resilience Act](https://jki.net/cra/) and are increasingly expected across regulated industries. Combined with static analysis, SBOM generation gives teams visibility into both the code they write and the components they depend on. See the [SBOM documentation](../sbom/index.md) to get started.
 
 !!! warning "Disclaimer"
     This notice is informational and not legal advice. For authoritative information about the EU CRA regulations, please visit [european-cyber-resilience-act.com](https://www.european-cyber-resilience-act.com).

--- a/docs/vipm-toml/nipm.md
+++ b/docs/vipm-toml/nipm.md
@@ -1,0 +1,209 @@
+---
+title: NI Packages (NIPM)
+---
+
+# Managing NI Packages with vipm.toml
+
+VIPM supports managing NI Package Manager (NIPM) dependencies alongside VIPM packages in a single `vipm.toml` manifest. This gives you a unified view of all your project's dependencies — both community packages from vipm.io and NI packages from NI feeds.
+
+## vipm.toml format
+
+NIPM dependencies use three dedicated sections in `vipm.toml`:
+
+```toml
+[nipm.feeds]
+ni = "https://download.ni.com/support/nipkg/products/ni-d/ni-daqmx/24.5/released/"
+
+[nipm.dependencies]
+ni-daqmx = "24.5.0"
+
+[nipm.dev-dependencies]
+ni-teststand = "2023.1.0"
+```
+
+### `[nipm.feeds]`
+
+Maps human-readable aliases to NI package feed URLs. Feed aliases are referenced by dependencies to specify where to download the package.
+
+```toml
+[nipm.feeds]
+ni-daqmx-feed = "https://download.ni.com/support/nipkg/products/ni-d/ni-daqmx/24.5/released/"
+ni-visa-feed = "https://download.ni.com/support/nipkg/products/ni-v/ni-visa/2024Q1/released/"
+```
+
+### `[nipm.dependencies]` and `[nipm.dev-dependencies]`
+
+Declare NIPM packages your project depends on. Two formats are supported:
+
+**Simple format** — version string only:
+
+```toml
+[nipm.dependencies]
+ni-daqmx = "24.5.0"
+```
+
+**Detailed format** — with feed alias:
+
+```toml
+[nipm.dependencies]
+ni-daqmx = { version = "24.5.0", feed = "ni-daqmx-feed" }
+```
+
+Use `[nipm.dev-dependencies]` for packages only needed during development or testing.
+
+!!! note
+    NIPM dependencies require explicit version numbers. Unlike VIPM packages, version auto-resolution is not available for NIPM packages.
+
+## Workflow
+
+### Adding NIPM dependencies
+
+Use `vipm add --nipm` to add NI packages to your manifest:
+
+```bash
+# Add with explicit version (required)
+vipm add --nipm ni-daqmx@24.5.0
+
+# Add with a feed alias
+vipm add --nipm ni-daqmx@24.5.0 --feed ni-daqmx-feed
+
+# Register a new feed and add the package
+vipm add --nipm ni-daqmx@24.5.0 --feed ni-daqmx-feed --feed-url "https://download.ni.com/..."
+
+# Add as a dev dependency
+vipm add --nipm ni-teststand@2023.1.0 --dev
+```
+
+On Windows with NI Package Manager installed, VIPM can auto-detect the installed version if you omit the version number, and can discover which feed provides the package.
+
+### Removing NIPM dependencies
+
+```bash
+vipm remove --nipm ni-daqmx
+vipm remove --nipm ni-teststand --dev
+```
+
+### Locking
+
+`vipm lock` includes NIPM dependencies in the lock file alongside VIPM packages:
+
+```bash
+vipm lock
+```
+
+The lock file records each NIPM package's name, version, feed URL, and checksum (when available).
+
+### Installing
+
+When you run `vipm install` on a project with NIPM dependencies, VIPM installs both VIPM and NIPM packages:
+
+```bash
+vipm install
+```
+
+!!! note "Windows only"
+    NIPM package installation requires Windows with NI Package Manager installed. On other platforms, VIPM manages the manifest entries but cannot install NI packages. VIPM will display a warning if NIPM is not available.
+
+!!! info "Planned: selective installation"
+    `vipm install` does not yet support `--no-nipm` or `--no-vipm` flags to install only one type of package. Currently it installs both VIPM and NIPM dependencies together.
+
+### Listing
+
+`vipm list` shows NIPM dependencies alongside VIPM packages when listing from a `vipm.toml`:
+
+```bash
+vipm list vipm.toml
+```
+
+!!! info "Planned: selective listing"
+    `vipm list` does not yet support `--no-nipm` or `--no-vipm` flags to filter by package type. Currently it shows all dependencies together.
+
+### Inspecting NI packages
+
+Use `vipm info --nipm` to view metadata for an installed NI package:
+
+```bash
+vipm info --nipm ni-daqmx
+```
+
+To see which files a package installed:
+
+```bash
+vipm info --nipm ni-daqmx --installed-files
+```
+
+`vipm info --nipm` requires Windows with NI Package Manager installed.
+
+## Filtering by package type
+
+Several commands include both VIPM and NIPM packages by default. Use `--no-nipm` or `--no-vipm` to filter:
+
+| Command | `--nipm` | `--no-nipm` | `--no-vipm` |
+|---------|----------|-------------|-------------|
+| `vipm add` | Select NIPM mode | — | — |
+| `vipm remove` | Select NIPM mode | — | — |
+| `vipm info` | Query NIPM package | — | — |
+| `vipm install` | — | Planned | Planned |
+| `vipm list` | — | Planned | Planned |
+| `vipm sbom` | — | Exclude NIPM | Exclude VIPM |
+| `vipm sync` | — | Exclude NIPM | Exclude VIPM |
+
+Examples:
+
+```bash
+# Generate SBOM with only VIPM packages
+vipm sbom vipm.toml --format cyclonedx --schema-version 1.5 --no-nipm --output bom.json
+
+# Generate SBOM with only NI packages
+vipm sbom vipm.toml --format cyclonedx --schema-version 1.5 --no-vipm --output bom.json
+
+# Sync vipm.toml from project, excluding NI packages
+vipm sync --from MyProject.lvproj --no-nipm
+```
+
+## Complete example
+
+```toml
+[project]
+name = "instrument-control"
+version = "1.0.0"
+labview-version = "2024"
+labview-bitness = 64
+
+[dependencies]
+oglib_array = "6.0.1.20"
+jki_lib_state_machine = "2.0.0.50"
+
+[dev-dependencies]
+caraya = "1.4.5.165"
+
+[nipm.feeds]
+ni-daq = "https://download.ni.com/support/nipkg/products/ni-d/ni-daqmx/24.5/released/"
+
+[nipm.dependencies]
+ni-daqmx = { version = "24.5.0", feed = "ni-daq" }
+
+[nipm.dev-dependencies]
+ni-teststand = "2023.1.0"
+```
+
+```bash
+# Add all dependencies
+vipm add oglib_array jki_lib_state_machine
+vipm add --dev caraya
+vipm add --nipm ni-daqmx@24.5.0 --feed ni-daq
+
+# Lock and install
+vipm lock
+vipm install
+
+# Generate SBOM including both VIPM and NI packages
+vipm sbom vipm.toml \
+  --format cyclonedx \
+  --schema-version 1.5 \
+  --product-name "Instrument Control" \
+  --product-version 1.0.0 \
+  --output build/bom.json
+```
+
+--8<-- "need-help.md"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,7 +54,12 @@ plugins:
 
 nav:
   - Home: index.md
-  - VIPM 2026Q1 Preview 3: preview.md
+  - VIPM 2026 Q3 Preview 1: preview.md
+  - Security: security/index.md
+  - SBOM:
+    - sbom/index.md
+    - sbom/getting-started.md
+    - sbom/workflows.md
   - vipm.toml (Preview):
     - vipm-toml/index.md
     - vipm-toml/getting-started.md
@@ -75,9 +80,9 @@ nav:
     - linux/index.md
     - linux/ubuntu.md
     - linux/VIPM Linux Crash on Package Installation - Permission Fix.md
-  - Security: security/index.md
   - Release notes:
     - release-notes/index.md
+    - release-notes/2026.1.md
     - release-notes/2025.3.1.md
     - release-notes/2025.3.md
     - release-notes/2024.3.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,6 +63,7 @@ nav:
   - vipm.toml (Preview):
     - vipm-toml/index.md
     - vipm-toml/getting-started.md
+    - vipm-toml/nipm.md
   - VIPM Edition Comparison: vipm-editions-comparison.md
   - Building packages:
     - building-packages/index.md
@@ -74,6 +75,7 @@ nav:
     - cli/index.md
     - cli/getting-started.md
     - cli/command-reference.md
+    - cli/environment-variables.md
     - cli/docker.md
     - cli/github-actions.md
   - Linux:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,9 @@ hooks:
 markdown_extensions:
   - admonition
   - attr_list
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.superfences
   - pymdownx.snippets:
       base_path: docs/.snippets
       check_paths: true


### PR DESCRIPTION
Users need documentation for SBOM generation, several undocumented CLI commands and parameters, environment variables for CI, and NIPM support in vipm.toml. This PR brings all Q3 preview documentation work into main.

## Summary

**SBOM documentation (new section):**
- Overview, getting started tutorial, and workflows guide
- Preview page rewritten for 2026 Q3 Preview 1
- 2026 Q1 release notes added
- Security page updated with SBOM cross-links

**CLI command reference updates:**
- New `vipm info` command (with `--nipm`, `--installed-files`)
- New `vipm sbom` and `vipm sync` commands (full reference)
- Missing parameters added to `install`, `uninstall`, `list`, `build`
- Missing global options: `--timeout`, `--show-progress`, `--verbose`

**New pages:**
- `cli/environment-variables.md` — CI detection, `VIPM_ASSUME_YES`, `VIPM_TIMEOUT`, `VIPM_DEBUG`, `NO_COLOR`, `SOURCE_DATE_EPOCH`, `VIPM_COMMUNITY_EDITION`
- `vipm-toml/nipm.md` — NIPM support guide with vipm.toml format, workflow, filtering flags, platform notes

**CI/CD docs:**
- `-y` flag added to Docker and GitHub Actions examples
- `VIPM_ASSUME_YES` tips added
- Docker `.env` example expanded with CI-recommended variables

**Site infrastructure:**
- Syntax highlighting enabled (`pymdownx.highlight` + `pymdownx.superfences`)

## Test plan

- [ ] `uv run mkdocs build --strict` passes
- [ ] All cross-links resolve correctly
- [ ] SBOM pages display Q3 preview admonition
- [ ] NIPM filtering table matches current CLI state
- [ ] Verify env var documentation against source code

Closes #52