### PR TITLE
Document VIPM_NONINTERACTIVE env var and CI auto-detection

### DIFF
--- a/docs/cli/command-reference.md
+++ b/docs/cli/command-reference.md
@@ -57,7 +57,7 @@ vipm install [OPTIONS] <package|path>...
 | `--upgrade` | If the package is already installed, upgrade it to the latest available version. |
 | `--dev` | Install dev-dependencies from `vipm.toml`. |
 | `--no-dev` | Exclude dev-dependencies when installing from `vipm.toml`. |
-| `--yes`, `-y` | Skip confirmation prompts and proceed automatically. |
+| `--yes`, `-y` | Skip confirmation prompts and proceed automatically. Also available as `VIPM_ASSUME_YES=1` env var, or use `VIPM_NONINTERACTIVE=1` to disable all prompts. See [Environment Variables](environment-variables.md). |
 
 ### Examples
 
@@ -106,7 +106,7 @@ vipm uninstall [OPTIONS] <package|package@version>...
 | Option | Description |
 |--------|-------------|
 | `--allow-version-mismatch`, `-F`, `--force` | Proceed even if the installed version does not match the requested version. |
-| `--yes`, `-y` | Skip confirmation prompts and proceed automatically. |
+| `--yes`, `-y` | Skip confirmation prompts and proceed automatically. Also available as `VIPM_ASSUME_YES=1` env var, or use `VIPM_NONINTERACTIVE=1` to disable all prompts. See [Environment Variables](environment-variables.md). |
 
 ### Examples
 

--- a/docs/cli/command-reference.md
+++ b/docs/cli/command-reference.md
@@ -510,4 +510,3 @@ Use `vipm about --help` to review the latest options.
 - [SBOM Generation](../sbom/index.md)
 - [Docker and Containers](docker.md)
 - [GitHub Actions and CI/CD](github-actions.md)
-- Project plan: `dev-docs/cli-docs-improvement-proposal.md`

--- a/docs/cli/docker.md
+++ b/docs/cli/docker.md
@@ -49,15 +49,12 @@ VIPM_SERIAL_NUMBER=your-serial-number-here
 VIPM_FULL_NAME=Your Full Name
 VIPM_EMAIL=your.email@example.com
 
-# Auto-confirm prompts (recommended for CI/CD)
-VIPM_ASSUME_YES=1
+# Non-interactive mode: auto-confirm prompts and error on missing params
+# (recommended for Docker/CI — prevents commands from hanging)
+VIPM_NONINTERACTIVE=1
 
 # Disable colored output for cleaner CI logs
 NO_COLOR=1
-
-# Set CI=true if running Docker outside a CI system (e.g. local testing)
-# to get longer default timeouts. Most CI runners set this automatically.
-# CI=true
 ```
 
 See [Environment Variables](environment-variables.md) for the full list and [GitHub Actions and CI/CD](github-actions.md) for workflow examples.
@@ -102,8 +99,8 @@ Once inside a running container, use the same CLI commands described in the [CLI
 
 > 💡 Because containers are often ephemeral, script these commands in your Docker entrypoint or CI workflow so every run activates, refreshes, installs, and verifies automatically.
 
-!!! tip "Skip prompts in CI"
-    Set `VIPM_ASSUME_YES=1` in your container environment to auto-confirm all prompts, or use the `-y` flag on individual commands. See [Environment Variables](environment-variables.md) for details.
+!!! tip "No extra configuration needed in CI"
+    When running inside a CI system (GitHub Actions, GitLab CI, etc.), VIPM auto-detects the environment and enables non-interactive mode. For standalone Docker usage outside CI, set `VIPM_NONINTERACTIVE=1` in your `.env` file to prevent commands from hanging on missing input. See [Environment Variables](environment-variables.md) for details.
 
 ## Building VI Packages in Containers
 

--- a/docs/cli/environment-variables.md
+++ b/docs/cli/environment-variables.md
@@ -124,7 +124,7 @@ export NO_COLOR=1
 
 ### `SOURCE_DATE_EPOCH`
 
-When set, VIPM uses this Unix timestamp for the `generated_at` field in `--json` output instead of the current time. This supports [reproducible builds](https://reproducible-builds.org/specs/source-date-epoch/).
+When set, VIPM uses this Unix timestamp for timestamps in structured output instead of the current time. This supports [reproducible builds](https://reproducible-builds.org/specs/source-date-epoch/).
 
 ```bash
 export SOURCE_DATE_EPOCH=1710000000

--- a/docs/cli/environment-variables.md
+++ b/docs/cli/environment-variables.md
@@ -27,19 +27,44 @@ VIPM automatically detects CI environments and adjusts its behavior — for exam
 
 No configuration is needed — if any of these variables are set, VIPM treats the environment as CI.
 
-!!! note
-    CI detection affects **timeouts only**. It does not automatically skip confirmation prompts. Use `VIPM_ASSUME_YES` or the `--yes` flag to skip prompts in CI. See [Confirmation Prompts](#confirmation-prompts) below.
+When a CI environment is detected and `VIPM_NONINTERACTIVE` is not explicitly set, VIPM automatically enables non-interactive mode: confirmation prompts are auto-accepted and missing required parameters cause immediate errors instead of hanging. See [Non-Interactive Mode](#vipm_noninteractive) below.
 
-## Confirmation Prompts
+## Non-Interactive Mode
+
+### `VIPM_NONINTERACTIVE`
+
+Disables all interactive prompts. Confirmation prompts are auto-accepted and missing required parameters cause immediate errors instead of blocking on stdin. This prevents commands from hanging in headless environments.
+
+**Auto-enabled in CI** — when a CI environment is detected (see [table above](#ci-environment-detection)) and `VIPM_NONINTERACTIVE` is not explicitly set, non-interactive mode activates automatically. Set `VIPM_NONINTERACTIVE=0` to override this and restore interactive behavior (useful for debugging in CI).
+
+```bash
+# Docker — no prompts at all
+export VIPM_NONINTERACTIVE=1
+vipm install project.vipc
+
+# CI — auto-detected, no configuration needed
+vipm install project.vipc
+
+# Override CI detection for debugging
+VIPM_NONINTERACTIVE=0 vipm install project.vipc
+```
+
+| Value | Behavior |
+|-------|----------|
+| `1`, `true`, `yes` (any truthy value) | Non-interactive: auto-confirm + error on missing params |
+| `0`, `false` | Disabled (overrides CI auto-detection) |
+| Empty string | Disabled (a warning is logged) |
+| Unset + CI detected | Non-interactive (auto-enabled) |
+| Unset + no CI | Interactive (default) |
 
 ### `VIPM_ASSUME_YES`
 
-Auto-confirms all interactive prompts without requiring the `--yes` / `-y` flag on each command. This is the recommended approach for CI/CD pipelines where you want all commands to proceed non-interactively.
+Auto-confirms confirmation prompts only (e.g., "Install 5 packages?") without requiring the `--yes` / `-y` flag on each command. Unlike `VIPM_NONINTERACTIVE`, commands with missing required parameters will still prompt for input.
 
 ```bash
 export VIPM_ASSUME_YES=1
-vipm install project.vipc     # no prompt
-vipm uninstall oglib_boolean  # no prompt
+vipm install project.vipc     # no confirmation prompt
+vipm uninstall oglib_boolean  # no confirmation prompt
 ```
 
 | Value | Behavior |
@@ -53,6 +78,17 @@ Alternatively, use the `--yes` / `-y` flag on individual commands:
 ```bash
 vipm install -y project.vipc
 ```
+
+### Precedence
+
+When multiple settings apply, VIPM uses this precedence order:
+
+1. `VIPM_NONINTERACTIVE=1` — non-interactive mode
+2. `VIPM_NONINTERACTIVE=0` — interactive (overrides CI detection)
+3. CI detected (if `VIPM_NONINTERACTIVE` unset) — non-interactive mode
+4. `VIPM_ASSUME_YES=1` — auto-confirm only (parameter prompts still work)
+5. `--yes` flag — auto-confirm for that command
+6. Default — fully interactive
 
 ## Timeouts
 

--- a/docs/cli/getting-started.md
+++ b/docs/cli/getting-started.md
@@ -118,7 +118,3 @@ Add `--labview-version` to focus on a specific LabVIEW release if you have more 
 - **Activation fails**: Confirm the serial number, name, and email match your VIPM account exactly; rerun `vipm activate` after updating secrets or environment variables.
 - **Package install fails**: Refresh metadata (`vipm package-list-refresh`) and double-check the package ID; add `--labview-version` when multiple LabVIEW versions are installed.
 - **Network issues**: Configure proxy variables (`http_proxy`, `https_proxy`) or use an internal repository mirror if the build machine cannot reach `vipm.io`.
-
-## Notes for Contributors
-
-This file currently serves as the quick-start outline. As the new command reference and troubleshooting docs come online, tighten each step to cross-reference those pages and keep duplication minimal.

--- a/docs/cli/github-actions.md
+++ b/docs/cli/github-actions.md
@@ -40,8 +40,8 @@ Store your VIPM Pro credentials as GitHub repository secrets:
 
 You can find your VIPM Pro serial number on the [VIPM account page](https://www.vipm.io/account/).
 
-!!! tip "Skip prompts in CI"
-    Use the `-y` flag on install/uninstall commands, or set `VIPM_ASSUME_YES=1` as an environment variable to auto-confirm all prompts across your workflow. See [Environment Variables](environment-variables.md) for details.
+!!! tip "Prompts are auto-disabled in CI"
+    VIPM automatically detects CI environments like GitHub Actions and enables non-interactive mode — confirmation prompts are auto-accepted and missing parameters cause immediate errors instead of hanging. No extra configuration is needed. You can also use the `-y` flag or `VIPM_ASSUME_YES=1` for explicit control. See [Environment Variables](environment-variables.md) for details.
 
 ### Basic Workflow Example
 

--- a/docs/release-notes/2026.3.md
+++ b/docs/release-notes/2026.3.md
@@ -1,11 +1,11 @@
 ---
-title: VIPM 2026 Q3
+title: VIPM 2026 Q3 Preview
 description: SBOM generation, vipm sync, vipm info, NI package management, new environment variables, and enhanced CI/CD support.
 ---
 
-# VIPM 2026 Q3 - Release Notes
+# VIPM 2026 Q3 Preview - Release Notes
 
-VIPM 2026 Q3 adds Software Bill of Materials (SBOM) generation, project synchronization with `vipm sync`, NI Package Manager (NIPM) dependency management in vipm.toml, and expanded CLI capabilities for automation and CI/CD.
+VIPM 2026 Q3 Preview adds Software Bill of Materials (SBOM) generation, project synchronization with `vipm sync`, NI Package Manager (NIPM) dependency management in vipm.toml, and expanded CLI capabilities for automation and CI/CD.
 
 Many of the new features and capabilities are visible in the `vipm` command-line interface (CLI).
 

--- a/docs/release-notes/2026.3.md
+++ b/docs/release-notes/2026.3.md
@@ -50,12 +50,13 @@ See the [NI Packages (NIPM) guide](../vipm-toml/nipm.md) for details.
 
 New environment variables simplify headless and CI/CD automation:
 
-- `VIPM_ASSUME_YES` — auto-confirm all prompts (recommended for CI/CD)
+- `VIPM_NONINTERACTIVE` — full non-interactive mode (auto-confirm prompts + error on missing params); auto-enabled in CI environments
+- `VIPM_ASSUME_YES` — auto-confirm confirmation prompts only
 - `VIPM_COMMUNITY_EDITION` — activate Community Edition without interactive prompts
 - `VIPM_TIMEOUT` — override the default operation timeout
 - `VIPM_DEBUG` — enable verbose debug output
 - `NO_COLOR` — disable colored output
-- Automatic CI environment detection for GitHub Actions, GitLab CI, Jenkins, and 9 other CI systems
+- Automatic CI environment detection for GitHub Actions, GitLab CI, Jenkins, and 9 other CI systems — non-interactive mode activates automatically so commands never hang
 
 See the [Environment Variables reference](../cli/environment-variables.md) for the full list.
 


### PR DESCRIPTION
## Summary

VIPM now auto-enables non-interactive mode in CI environments, preventing commands from hanging on missing input. The existing docs incorrectly stated that CI detection "affects timeouts only" — it now also controls prompt behavior. These changes document the `VIPM_NONINTERACTIVE` env var and update all CI/automation guides to reflect the new behavior.

- **Environment variables reference** — added `VIPM_NONINTERACTIVE` section with behavior table, precedence rules, and usage examples; corrected CI detection note; restructured `VIPM_ASSUME_YES` as a subsection under the new Non-Interactive Mode heading
- **GitHub Actions guide** — updated tip box to explain CI auto-detection instead of requiring manual `--yes` configuration
- **Docker guide** — updated `.env` example to use `VIPM_NONINTERACTIVE=1`; updated tip to distinguish standalone Docker from CI-hosted containers
- **Command reference** — added env var cross-references to `--yes` flag descriptions for install and uninstall
- **2026.3 release notes** — added `VIPM_NONINTERACTIVE` to the env vars list; updated CI detection bullet

## Test plan

- [ ] Verify mkdocs builds without errors
- [ ] Verify all internal cross-references resolve (e.g., `#vipm_noninteractive` anchor)
- [ ] Review rendered pages for formatting and readability