### PR TITLE
Document dev-dependency preservation in vipm.lock (2026.3)

### DIFF
--- a/docs/release-notes/2026.3.md
+++ b/docs/release-notes/2026.3.md
@@ -64,4 +64,9 @@ See the [Environment Variables reference](../cli/environment-variables.md) for t
 
 Updated [Docker](../cli/docker.md) and [GitHub Actions](../cli/github-actions.md) guides with environment variable configuration, `-y` flag usage in examples, and SBOM generation workflow steps.
 
+## Additional improvements
+
+- `vipm install` now preserves dev-dependencies in `vipm.lock` even when running without `--dev`, so the lock file always reflects the full resolved dependency graph (both production and dev-dependencies), matching the convention of other lock-file-based package managers.
+- `vipm lock --dev` and `vipm lock --no-dev` flags were removed in this release — the lock file now always includes dev-dependencies, so these flags no longer have an effect. Remove them from any scripts that pass them.
+
 --8<-- "need-help.md"


### PR DESCRIPTION
## Summary

Users upgrading to VIPM 2026.3 need to know two things about `vipm.lock` behavior:

1. `vipm install` now preserves dev-dependencies in the lock file even when run without `--dev`, so the lock always reflects the full resolved dependency graph.
2. The `vipm lock --dev` and `vipm lock --no-dev` flags were removed. Scripts that pass them will fail with an "unrecognized argument" error after upgrade.

Without release-notes coverage, users with CI scripts that pass those flags would be surprised at upgrade time, and the behavior change in `vipm install` would go unannounced.

## Changes

- Added an "Additional improvements" section to `docs/release-notes/2026.3.md` with two bullets covering the lock preservation fix and the flag removal.

## Test plan

- [x] `uv run mkdocs build --strict` succeeds with no warnings