### PR TITLE
Remove references to vipm lock --no-dev flag (2026.3)

### DIFF
--- a/docs/vipm-toml/getting-started.md
+++ b/docs/vipm-toml/getting-started.md
@@ -207,11 +207,8 @@ The `vipm.lock` file captures exact versions of all installed packages, ensuring
 ### Generating a Lock File
 
 ```bash
-# Generate/update vipm.lock from vipm.toml (includes dev dependencies by default)
+# Generate/update vipm.lock from vipm.toml (always includes dev-dependencies)
 vipm lock
-
-# Exclude dev dependencies from the lock file
-vipm lock --no-dev
 
 # Continue with incomplete lock file when specs cannot be fetched
 vipm lock --best-effort
@@ -656,7 +653,7 @@ For detailed documentation on all CLI commands, see the [CLI Command Reference](
 | `vipm add <packages>` | Add dependencies to vipm.toml (`--dev`, `--install`) |
 | `vipm remove <packages>` | Remove dependencies from vipm.toml (`--dev`) |
 | `vipm install` | Install dependencies from vipm.toml (`--dev`, `--no-dev`, `--upgrade`) |
-| `vipm lock` | Generate/update vipm.lock (`--no-dev`, `--best-effort`) |
+| `vipm lock` | Generate/update vipm.lock (`--best-effort`) |
 | `vipm lock --check` | Verify lock file is in sync (for CI) |
 | `vipm build [name]` | Build targets defined in vipm.toml (`--all`, `--debug`, `--version-number`) |
 | `vipm clean [name]` | Remove build output directories (`--all`, `--dry-run`) |


### PR DESCRIPTION
## Summary

The `vipm lock --no-dev` flag was removed in VIPM 2026.3 — the lock file now always includes both production and dev-dependencies. Two places in the vipm.toml getting-started guide still demonstrated the removed flag, which would confuse readers who copied the examples or trusted the command-reference table. Users following the guide on 2026.3 would hit a clap "unrecognized argument" error.

## Changes

- `docs/vipm-toml/getting-started.md` — drop the `vipm lock --no-dev` example block and rewrite the `vipm lock` comment to say dev-dependencies are always included.
- `docs/vipm-toml/getting-started.md` — update the Command Reference table entry for `vipm lock` to list only `--best-effort`.

## Test plan

- [x] `uv run mkdocs build --strict` succeeds with no warnings
- [x] `grep` confirms no remaining `vipm lock --no-dev` references in `docs/`