### PR TITLE
docs(sbom): document --lvproj-target and --lvproj-build-spec

### DIFF
--- a/docs/cli/command-reference.md
+++ b/docs/cli/command-reference.md
@@ -379,6 +379,8 @@ vipm sbom [INPUT] --format cyclonedx --schema-version 1.5 --output <PATH> [OPTIO
 | `--no-dev` | Exclude dev-dependencies (`vipm.toml` input only). |
 | `--follow-linker` | Follow the VI linker to discover subVI dependencies (`.lvproj` input only). |
 | `--follow-depth <N>` | Linker traversal depth limit. Requires `--follow-linker`. |
+| `--lvproj-build-spec <NAME>` | Select a build specification within a `.lvproj`. Seeds `metadata.component` name, version, and type from the build spec (overridden by explicit `--product-*` flags) and narrows the dependency scan to the build spec's containing target. The target is inferred automatically when unambiguous; pass `--lvproj-target` to disambiguate when the same name exists under multiple targets. `.lvproj` input only. |
+| `--lvproj-target <TARGET>` | Narrow the dependency scan to a single `.lvproj` target. May be used alone (scans only that target) or with `--lvproj-build-spec` (validates the spec is under that target). Omit to scan the whole project. An unknown target name produces exit code `12` with a listing of the project's available targets. `.lvproj` input only. |
 
 ### Examples
 
@@ -390,6 +392,27 @@ vipm sbom MyProject.lvproj \
   --schema-version 1.5 \
   --product-name "My Instrument" \
   --product-version 2.1.0 \
+  --output build/bom.json
+```
+
+Scope an SBOM to a specific build specification within a `.lvproj`:
+
+```bash
+vipm sbom MyProject.lvproj \
+  --format cyclonedx \
+  --schema-version 1.5 \
+  --lvproj-build-spec "My EXE Build" \
+  --lvproj-target "My Computer" \
+  --output build/bom.json
+```
+
+Scope to a specific target without selecting a build spec (useful when running from source without building a binary):
+
+```bash
+vipm sbom MyProject.lvproj \
+  --format cyclonedx \
+  --schema-version 1.5 \
+  --lvproj-target "My Computer" \
   --output build/bom.json
 ```
 
@@ -419,6 +442,7 @@ SBOM written to build/bom.json
 | `4` | Requested LabVIEW version is not installed |
 | `6` | Insufficient edition, license, or activation |
 | `8` | File system or IO failure (e.g., cannot write to `--output` path) |
+| `12` | Named build target (`--lvproj-target`) not found in the `.lvproj` |
 | `13` | Input file is not a supported type |
 | `14` | Input file exists but is malformed |
 | `15` | A required file does not exist |

--- a/docs/sbom/workflows.md
+++ b/docs/sbom/workflows.md
@@ -79,6 +79,33 @@ vipm sbom MyProject.lvproj \
   --output build/bom.json
 ```
 
+### Scoping to a target or build specification
+
+A `.lvproj` may contain multiple *targets* (e.g., `My Computer`, RT controllers) and multiple *build specifications* per target. By default, `vipm sbom` scans every file under every target. To narrow the SBOM to a specific deliverable, use `--lvproj-target` or `--lvproj-build-spec`:
+
+Scope to a single target (useful when running code from source without building a binary):
+
+```bash
+vipm sbom MyProject.lvproj \
+  --format cyclonedx \
+  --schema-version 1.5 \
+  --lvproj-target "My Computer" \
+  --output build/bom.json
+```
+
+Scope to a specific build specification. The build spec's product name, version, and type are applied to the SBOM's top-level component automatically, and the dependency scan is narrowed to the build spec's containing target:
+
+```bash
+vipm sbom MyProject.lvproj \
+  --format cyclonedx \
+  --schema-version 1.5 \
+  --lvproj-build-spec "My EXE Build" \
+  --lvproj-target "My Computer" \
+  --output build/bom.json
+```
+
+If the build spec name is unique across the project, `--lvproj-target` can be omitted — it will be inferred. Pass it explicitly (for example, from a CI or IDE integration) to avoid ambiguity when the same name exists under multiple targets.
+
 ### Following the VI linker
 
 For deeper dependency discovery, use `--follow-linker` to trace subVI dependencies through the LabVIEW linker:


### PR DESCRIPTION
## Summary

Documents the `--lvproj-target` and `--lvproj-build-spec` flags for `vipm sbom`, including the exit code and error behavior for an unknown target.

## Why

The CLI now narrows an SBOM's dependency scan to a specific `.lvproj` target (explicitly via `--lvproj-target`, or inferred from `--lvproj-build-spec`). The public docs didn't mention either flag for `vipm sbom` — users had no way to discover this from the reference page or the SBOM workflow guide.

## Changes

- `docs/cli/command-reference.md`
  - Added `--lvproj-build-spec` and `--lvproj-target` rows to the `vipm sbom` Options table.
  - Added two examples under `vipm sbom`: build-spec + target, and target-only.
  - Added exit code `12` (named build target not found) to the Exit Codes table.
- `docs/sbom/workflows.md`
  - New "Scoping to a target or build specification" subsection with worked examples between the project-based generation and linker sections.

## Test plan

- [x] `mkdocs serve` locally; verify the new sbom options, examples, and workflow subsection render.
- [x] Follow the two new sbom examples visually — confirm flag names match the CLI's `--help` output.