### PR TITLE
docs(sbom): preserve dotted version in root component bom-ref examples

### DIFF
--- a/docs/sbom/output-reference.md
+++ b/docs/sbom/output-reference.md
@@ -69,7 +69,7 @@ The root component — your product. This is set by the `--product-name`, `--pro
   "type": "application",
   "name": "My Instrument",
   "version": "2.1.0",
-  "bom-ref": "pkg:vipm/My-Instrument@2-1-0"
+  "bom-ref": "pkg:vipm/My-Instrument@2.1.0"
 }
 ```
 
@@ -138,7 +138,7 @@ The `dependencies` section records the relationship between your product and its
 ```json
 "dependencies": [
   {
-    "ref": "pkg:vipm/My-Instrument@2-1-0",
+    "ref": "pkg:vipm/My-Instrument@2.1.0",
     "dependsOn": [
       "pkg:vipm/oglib_file@6.0.2.28",
       "pkg:vipm/jki_state_machine@2020.0.2.50",
@@ -340,7 +340,7 @@ Below is an annotated example of a complete CycloneDX 1.5 SBOM generated from a 
       "type": "application",
       "name": "Acme Widget Tester",
       "version": "2.1.0",
-      "bom-ref": "pkg:vipm/Acme-Widget-Tester@2-1-0"
+      "bom-ref": "pkg:vipm/Acme-Widget-Tester@2.1.0"
     }
   },
 
@@ -395,7 +395,7 @@ Below is an annotated example of a complete CycloneDX 1.5 SBOM generated from a 
 
   "dependencies": [
     {
-      "ref": "pkg:vipm/Acme-Widget-Tester@2-1-0",
+      "ref": "pkg:vipm/Acme-Widget-Tester@2.1.0",
       "dependsOn": [
         "pkg:vipm/oglib_file@6.0.2.28",
         "pkg:nipkg/ni-daqmx@23.8.0.49349-0%2Bf197?feed=https://download.ni.com/support/nipkg/products/ni-d/ni-daqmx/23.8/released"


### PR DESCRIPTION
## Summary

The root component's `bom-ref` is a Package URL, and the [purl spec](https://github.com/package-url/purl-spec) lists `.` as an unreserved character in the version segment. The annotated SBOM examples in `docs/sbom/output-reference.md` previously showed the version with hyphens (`@2-1-0`) — match the spec by writing the version as `@2.1.0`, which is also what the tool actually generates.

Four lines updated:

- The `metadata.component` example
- The `dependencies` example referencing the root
- The annotated full-document example's `metadata.component`
- The annotated full-document example's `dependencies` entry referencing the root

## Test plan

- [x] `grep -n '@\d+-\d+' docs/sbom/output-reference.md` returns no matches
- [ ] `mkdocs serve` renders without warnings