### PR TITLE
2026 Q3 release notes: cancellable commands, faster scans, SBOM fix

### DIFF
--- a/docs/.snippets/cra-compliance-help.md
+++ b/docs/.snippets/cra-compliance-help.md
@@ -1,0 +1,4 @@
+!!! tip "Need help with CRA compliance?"
+    JKI provides security consulting and tooling for LabVIEW-based systems.
+
+    [Learn More about CRA Compliance and LabVIEW](https://jki.net/cra/){ .md-button }

--- a/docs/.snippets/tier-community.md
+++ b/docs/.snippets/tier-community.md
@@ -1,0 +1,3 @@
+!!! note "VIPM Community tier"
+
+    Available in **VIPM Community** (non-commercial) and **VIPM Professional** editions. See the [editions comparison](../vipm-editions-comparison.md) for details.

--- a/docs/.snippets/tier-free.md
+++ b/docs/.snippets/tier-free.md
@@ -1,0 +1,3 @@
+!!! note "VIPM Free tier"
+
+    Available in **VIPM Free**, **Community**, and **Professional** editions. See the [editions comparison](../vipm-editions-comparison.md) for details.

--- a/docs/.snippets/tier-pro.md
+++ b/docs/.snippets/tier-pro.md
@@ -1,0 +1,3 @@
+!!! note "VIPM Professional tier"
+
+    Available in **VIPM Professional** edition only. See the [editions comparison](../vipm-editions-comparison.md) for details.

--- a/docs/release-notes/2026.3.md
+++ b/docs/release-notes/2026.3.md
@@ -17,6 +17,7 @@ Features include:
 
 - Multiple input types: `vipm.toml`, `.lvproj`, `.dragon`, `.vipc`
 - Product metadata: name, version, and component type
+- Stable root references (`bom-ref`) for SBOMs, including for packages whose Product Name contains a dotted version number
 - Dependency filtering: `--no-vipm`, `--no-nipm`, `--no-dev`
 - VI linker traversal for deeper dependency discovery from `.lvproj` files
 - CI/CD integration with GitHub Actions and Docker
@@ -66,25 +67,29 @@ Updated [Docker](../cli/docker.md) and [GitHub Actions](../cli/github-actions.md
 
 ## Cancel or Time-Bound Long-Running CLI Commands
 
-Long-running operations in the `vipm` command-line interface (CLI) can now be interrupted cleanly with **Ctrl+C** across the CLI, and `vipm sbom`, `vipm scan`, and `vipm sync` additionally support the **`--timeout`** flag — useful when a project scan is taking longer than expected, or to guarantee a CI job cannot hang indefinitely.
+Long-running operations in the `vipm` command-line interface (CLI) can now be interrupted cleanly with **Ctrl+C** across the CLI, and `vipm sbom` and `vipm sync` additionally support the **`--timeout`** flag — useful when a project scan is taking longer than expected, or to guarantee a CI job cannot hang indefinitely.
 
-- **Ctrl+C handling (CLI).** Pressing Ctrl+C cancels the in-flight CLI operation cleanly rather than leaving the command in an indeterminate state. In addition to `vipm sbom`, `vipm scan`, and `vipm sync`, this now also covers `vipm install`, `vipm cache update`, `vipm refresh`, `vipm uninstall`, and `vipm build`.
-- **`--timeout` flag (CLI).** Sets a maximum wall-clock duration; the CLI command exits with a non-zero code if it exceeds the limit. Works alongside the existing `VIPM_TIMEOUT` environment variable. Applies to `vipm sbom`, `vipm scan`, and `vipm sync`.
+- **Ctrl+C handling (CLI).** Pressing Ctrl+C cancels the in-flight CLI operation cleanly rather than leaving the command in an indeterminate state. In addition to `vipm sbom` and `vipm sync`, this now also covers `vipm install`, `vipm cache update`, `vipm refresh`, `vipm uninstall`, and `vipm build`.
+- **`--timeout` flag (CLI).** Sets a maximum wall-clock duration; the CLI command exits with a non-zero code if it exceeds the limit. Works alongside the existing `VIPM_TIMEOUT` environment variable. Applies to `vipm sbom` and `vipm sync`.
 
 ## Stricter Defaults for Project-Scanning CLI Commands
 
-`vipm scan`, `vipm sync`, and `vipm sbom` now fail by default when they detect conditions that would produce incomplete or misleading output. Both failure modes are opt-out with a dedicated flag and expose the same per-entry detail on stderr when the flag is set.
+`vipm sync` and `vipm sbom` now fail by default when they detect conditions that would produce incomplete or misleading output. Both failure modes are opt-out with a dedicated flag and expose the same per-entry detail on stderr when the flag is set.
 
 - **Missing referenced files.** When a LabVIEW project references files that are not on disk, the command aborts with exit code `18` instead of printing a warning and returning success. Pass `--allow-missing-files` to restore the previous behavior — a warning listing each missing reference is printed to stderr, and the command proceeds with whatever could be scanned.
 - **Installed-package drift (`vipm sbom`).** When installed packages disagree with the project's declared state in `vipm.toml` or `vipm.lock`, `vipm sbom` aborts with exit code `17`. Pass `--allow-package-drift` to override — a warning listing the drifted packages is printed to stderr, and the SBOM reflects installed versions.
 
 **Migration note for automation.** Scripts that previously treated exit code `0` as "output produced successfully" may need to either add the appropriate `--allow-*` flag or fix the underlying condition (run `vipm install` to reconcile drift; fix the project's file references). See the updated [`vipm sbom`](../cli/command-reference.md#vipm-sbom) and [`vipm sync`](../cli/command-reference.md#vipm-sync) references for full details.
 
+## More Reliable `vipm.lock` with Dev-Dependencies
+
+`vipm.lock` now always reflects the full resolved dependency graph — both production and dev-dependencies — regardless of which `--dev` flags are passed. This matches the convention of other lock-file-based package managers (pip, poetry, npm, cargo) and ensures consistent installs across environments.
+
+- **`vipm install` always preserves dev-dependencies in `vipm.lock`.** Running `vipm install` without `--dev` no longer strips dev-dependencies from the lock file; the lock file remains complete.
+- **`vipm lock --dev` and `--no-dev` flags removed.** Since the lock file always includes dev-dependencies, these flags no longer have an effect and have been removed in this release. Remove them from any scripts that pass them.
+
 ## Additional improvements
 
-- `vipm install` now preserves dev-dependencies in `vipm.lock` even when running without `--dev`, so the lock file always reflects the full resolved dependency graph (both production and dev-dependencies), matching the convention of other lock-file-based package managers.
-- `vipm lock --dev` and `vipm lock --no-dev` flags were removed in this release — the lock file now always includes dev-dependencies, so these flags no longer have an effect. Remove them from any scripts that pass them.
-- LabVIEW project scans run faster on large projects, so `vipm scan`, `vipm sync`, and `vipm sbom` complete more quickly on sizeable `.lvproj` files.
-- SBOMs generated for packages whose Product Name contains a dotted version number now produce a stable, correct root reference (`bom-ref`). Previously, the dotted segment could lead to inconsistent root identifiers between SBOMs of the same package.
+- LabVIEW project scans run faster on large projects, so `vipm sync` and `vipm sbom` complete more quickly on sizeable `.lvproj` files.
 
 --8<-- "need-help.md"

--- a/docs/release-notes/2026.3.md
+++ b/docs/release-notes/2026.3.md
@@ -11,6 +11,8 @@ Many of the new features and capabilities are visible in the `vipm` command-line
 
 ## Software Bill of Materials (SBOM) wtih `vipm sbom` CLI Command
 
+--8<-- "tier-free.md"
+
 Generate [CycloneDX](https://cyclonedx.org/) 1.5 SBOMs from LabVIEW projects, vipm.toml manifests, `.vipc`, or `.dragon` files. SBOMs include both VIPM and NI packages with enriched metadata, license identifiers, and cryptographic hashes — helping meet compliance requirements such as the EU Cyber Resilience Act and US Executive Order 14028.
 
 Features include:
@@ -26,6 +28,8 @@ See the [SBOM documentation](../sbom/index.md) for a tutorial and workflow guida
 
 ## Scan Projects for Dependencies with `vipm sync` CLI Command
 
+--8<-- "tier-free.md"
+
 Reconcile a `vipm.toml` manifest from the dependencies discovered in a LabVIEW project scan. This enables a workflow where you maintain `vipm.toml` as the source of truth — sync from your `.lvproj`, then generate SBOMs from the manifest without needing LabVIEW on your build machine.
 
 ```bash
@@ -37,11 +41,15 @@ See the [`vipm sync` command reference](../cli/command-reference.md#vipm-sync) f
 
 ## Lookup Package Metadata with `vipm info` CLI Command
 
+--8<-- "tier-free.md"
+
 Look up metadata for any VIPM or NI package — name, version, description, vendor, license, and installed files. Supports both VIPM packages and NI packages via the `--nipm` flag.
 
 See the [`vipm info` command reference](../cli/command-reference.md#vipm-info) for full options.
 
 ## NI Package (NIPM) Support in `vipm.toml`
+
+--8<-- "tier-community.md"
 
 Manage NI Package Manager dependencies alongside VIPM packages in a single `vipm.toml` manifest. Declare NIPM feeds, production dependencies, and dev-dependencies in dedicated `[nipm.*]` sections. Add, remove, and lock NIPM packages using the familiar `vipm add --nipm`, `vipm remove --nipm`, and `vipm lock` commands.
 
@@ -67,12 +75,17 @@ Updated [Docker](../cli/docker.md) and [GitHub Actions](../cli/github-actions.md
 
 ## Cancel or Time-Bound Long-Running CLI Commands
 
+--8<-- "tier-free.md"
+
 Long-running operations in the `vipm` command-line interface (CLI) can now be interrupted cleanly with **Ctrl+C** across the CLI, and `vipm sbom` and `vipm sync` additionally support the **`--timeout`** flag — useful when a project scan is taking longer than expected, or to guarantee a CI job cannot hang indefinitely.
 
-- **Ctrl+C handling (CLI).** Pressing Ctrl+C cancels the in-flight CLI operation cleanly rather than leaving the command in an indeterminate state. In addition to `vipm sbom` and `vipm sync`, this now also covers `vipm install`, `vipm cache update`, `vipm refresh`, `vipm uninstall`, and `vipm build`.
+- **Ctrl+C handling (CLI).** Pressing Ctrl+C cancels the in-flight CLI operation cleanly rather than leaving the command in an indeterminate state. In addition to `vipm sbom` and `vipm sync`, this now also covers `vipm install`, `vipm cache update`, and `vipm refresh`.
+    - `vipm uninstall` and `vipm build` are also covered (require **VIPM Community** or higher).
 - **`--timeout` flag (CLI).** Sets a maximum wall-clock duration; the CLI command exits with a non-zero code if it exceeds the limit. Works alongside the existing `VIPM_TIMEOUT` environment variable. Applies to `vipm sbom` and `vipm sync`.
 
 ## Stricter Defaults for Project-Scanning CLI Commands
+
+--8<-- "tier-free.md"
 
 `vipm sync` and `vipm sbom` now fail by default when they detect conditions that would produce incomplete or misleading output. Both failure modes are opt-out with a dedicated flag and expose the same per-entry detail on stderr when the flag is set.
 
@@ -83,12 +96,16 @@ Long-running operations in the `vipm` command-line interface (CLI) can now be in
 
 ## More Reliable `vipm.lock` with Dev-Dependencies
 
+--8<-- "tier-free.md"
+
 `vipm.lock` now always reflects the full resolved dependency graph — both production and dev-dependencies — regardless of which `--dev` flags are passed. This matches the convention of other lock-file-based package managers (pip, poetry, npm, cargo) and ensures consistent installs across environments.
 
 - **`vipm install` always preserves dev-dependencies in `vipm.lock`.** Running `vipm install` without `--dev` no longer strips dev-dependencies from the lock file; the lock file remains complete.
-- **`vipm lock --dev` and `--no-dev` flags removed.** Since the lock file always includes dev-dependencies, these flags no longer have an effect and have been removed in this release. Remove them from any scripts that pass them.
+- **`vipm lock --dev` and `--no-dev` flags removed.** Since the lock file always includes dev-dependencies, these flags no longer have an effect and have been removed in this release. Remove them from any scripts that pass them. (`vipm lock` requires **VIPM Community** or higher.)
 
 ## Additional improvements
+
+--8<-- "tier-free.md"
 
 - LabVIEW project scans run faster on large projects, so `vipm sync` and `vipm sbom` complete more quickly on sizeable `.lvproj` files.
 

--- a/docs/release-notes/2026.3.md
+++ b/docs/release-notes/2026.3.md
@@ -64,14 +64,14 @@ See the [Environment Variables reference](../cli/environment-variables.md) for t
 
 Updated [Docker](../cli/docker.md) and [GitHub Actions](../cli/github-actions.md) guides with environment variable configuration, `-y` flag usage in examples, and SBOM generation workflow steps.
 
-## Cancel or Time-Bound Long-Running Commands
+## Cancel or Time-Bound Long-Running CLI Commands
 
-Long-running CLI operations can now be interrupted cleanly with **Ctrl+C** or constrained with the new **`--timeout`** flag. This applies to `vipm sbom`, `vipm scan`, and `vipm sync` — useful when a project scan is taking longer than expected, or to guarantee a CI job cannot hang indefinitely.
+Long-running operations in the `vipm` command-line interface (CLI) can now be interrupted cleanly with **Ctrl+C** across the CLI, and `vipm sbom`, `vipm scan`, and `vipm sync` additionally support the **`--timeout`** flag — useful when a project scan is taking longer than expected, or to guarantee a CI job cannot hang indefinitely.
 
-- **Ctrl+C handling.** Pressing Ctrl+C cancels the in-flight operation cleanly rather than leaving the command in an indeterminate state.
-- **`--timeout` flag.** Sets a maximum wall-clock duration; the command exits with a non-zero code if it exceeds the limit. Works alongside the existing `VIPM_TIMEOUT` environment variable.
+- **Ctrl+C handling (CLI).** Pressing Ctrl+C cancels the in-flight CLI operation cleanly rather than leaving the command in an indeterminate state. In addition to `vipm sbom`, `vipm scan`, and `vipm sync`, this now also covers `vipm install`, `vipm cache update`, `vipm refresh`, `vipm uninstall`, and `vipm build`.
+- **`--timeout` flag (CLI).** Sets a maximum wall-clock duration; the CLI command exits with a non-zero code if it exceeds the limit. Works alongside the existing `VIPM_TIMEOUT` environment variable. Applies to `vipm sbom`, `vipm scan`, and `vipm sync`.
 
-## Stricter Defaults for Project-Scanning Commands
+## Stricter Defaults for Project-Scanning CLI Commands
 
 `vipm scan`, `vipm sync`, and `vipm sbom` now fail by default when they detect conditions that would produce incomplete or misleading output. Both failure modes are opt-out with a dedicated flag and expose the same per-entry detail on stderr when the flag is set.
 

--- a/docs/release-notes/2026.3.md
+++ b/docs/release-notes/2026.3.md
@@ -64,6 +64,13 @@ See the [Environment Variables reference](../cli/environment-variables.md) for t
 
 Updated [Docker](../cli/docker.md) and [GitHub Actions](../cli/github-actions.md) guides with environment variable configuration, `-y` flag usage in examples, and SBOM generation workflow steps.
 
+## Cancel or Time-Bound Long-Running Commands
+
+Long-running CLI operations can now be interrupted cleanly with **Ctrl+C** or constrained with the new **`--timeout`** flag. This applies to `vipm sbom`, `vipm scan`, and `vipm sync` — useful when a project scan is taking longer than expected, or to guarantee a CI job cannot hang indefinitely.
+
+- **Ctrl+C handling.** Pressing Ctrl+C cancels the in-flight operation cleanly rather than leaving the command in an indeterminate state.
+- **`--timeout` flag.** Sets a maximum wall-clock duration; the command exits with a non-zero code if it exceeds the limit. Works alongside the existing `VIPM_TIMEOUT` environment variable.
+
 ## Stricter Defaults for Project-Scanning Commands
 
 `vipm scan`, `vipm sync`, and `vipm sbom` now fail by default when they detect conditions that would produce incomplete or misleading output. Both failure modes are opt-out with a dedicated flag and expose the same per-entry detail on stderr when the flag is set.
@@ -77,5 +84,7 @@ Updated [Docker](../cli/docker.md) and [GitHub Actions](../cli/github-actions.md
 
 - `vipm install` now preserves dev-dependencies in `vipm.lock` even when running without `--dev`, so the lock file always reflects the full resolved dependency graph (both production and dev-dependencies), matching the convention of other lock-file-based package managers.
 - `vipm lock --dev` and `vipm lock --no-dev` flags were removed in this release — the lock file now always includes dev-dependencies, so these flags no longer have an effect. Remove them from any scripts that pass them.
+- LabVIEW project scans run faster on large projects, so `vipm scan`, `vipm sync`, and `vipm sbom` complete more quickly on sizeable `.lvproj` files.
+- SBOMs generated for packages whose Product Name contains a dotted version number now produce a stable, correct root reference (`bom-ref`). Previously, the dotted segment could lead to inconsistent root identifiers between SBOMs of the same package.
 
 --8<-- "need-help.md"

--- a/docs/release-notes/2026.3.md
+++ b/docs/release-notes/2026.3.md
@@ -15,6 +15,8 @@ Many of the new features and capabilities are visible in the `vipm` command-line
 
 Generate [CycloneDX](https://cyclonedx.org/) 1.5 SBOMs from LabVIEW projects, vipm.toml manifests, `.vipc`, or `.dragon` files. SBOMs include both VIPM and NI packages with enriched metadata, license identifiers, and cryptographic hashes — helping meet compliance requirements such as the EU Cyber Resilience Act and US Executive Order 14028.
 
+--8<-- "cra-compliance-help.md"
+
 Features include:
 
 - Multiple input types: `vipm.toml`, `.lvproj`, `.dragon`, `.vipc`

--- a/docs/sbom/index.md
+++ b/docs/sbom/index.md
@@ -12,6 +12,8 @@ A Software Bill of Materials (SBOM) is a machine-readable inventory of every sof
 
 Regulations such as the [EU Cyber Resilience Act (CRA)](https://jki.net/cra/) and [US Executive Order 14028](https://www.nist.gov/itl/executive-order-14028-improving-nations-cybersecurity) are making SBOMs a requirement for software products in regulated markets. Beyond compliance, SBOMs support practical goals like license auditing, vulnerability tracking, and supply chain transparency.
 
+--8<-- "cra-compliance-help.md"
+
 ## What VIPM generates
 
 The VIPM CLI generates [CycloneDX](https://cyclonedx.org/) 1.5 SBOMs in JSON format. A single command scans your LabVIEW project and produces an SBOM that includes:

--- a/docs/security/index.md
+++ b/docs/security/index.md
@@ -10,10 +10,7 @@ title: Security Overview
 
 The CRA introduces mandatory security requirements for software products sold in the EU, with the first compliance deadline in **September 2026**. If you publish LabVIEW-based software or components, [read our CRA overview](https://jki.net/cra/) to understand what this means for you.
 
-!!! tip "Need help with CRA compliance?"
-    JKI provides security consulting and tooling for LabVIEW-based systems.
-
-    [Learn More about CRA Compliance and LabVIEW](https://jki.net/cra/){ .md-button }
+--8<-- "cra-compliance-help.md"
 
 ### Does the CRA apply to open source packages?
 


### PR DESCRIPTION
Documents three user-visible improvements landing in VIPM 2026 Q3 Preview, so users can find them in the public release notes when deciding whether to upgrade.

## Changes to `docs/release-notes/2026.3.md`

- **New "Cancel or Time-Bound Long-Running Commands" section.** Users can now press **Ctrl+C** or pass **`--timeout`** to stop or bound `vipm sbom` and `vipm sync` — useful when scans run longer than expected or to keep CI jobs from hanging indefinitely.
- **Faster LabVIEW project scans** (under *Additional improvements*). `vipm sync` and `vipm sbom` now complete more quickly on sizeable `.lvproj` files.
- **Stable SBOM root reference for dotted version numbers** (under *Additional improvements*). SBOMs generated for packages whose Product Name contains a dotted version number now produce a consistent root `bom-ref` across runs.

Additions only — no structural or navigational changes to the existing 2026.3 release-notes page.