### PR TITLE
Rework tier badges as compact colored pills; drop Free badges from 2026.3

### DIFF
--- a/docs/.snippets/tier-community.md
+++ b/docs/.snippets/tier-community.md
@@ -1,3 +1,1 @@
-!!! note "VIPM Community tier"
-
-    Available in **VIPM Community** (non-commercial) and **VIPM Professional** editions. See the [editions comparison](../vipm-editions-comparison.md) for details.
+[VIPM Community](../vipm-editions-comparison.md#available-editions){ .md-button .vipm-tier-pill .vipm-tier-community }

--- a/docs/.snippets/tier-free.md
+++ b/docs/.snippets/tier-free.md
@@ -1,3 +1,1 @@
-!!! note "VIPM Free tier"
-
-    Available in **VIPM Free**, **Community**, and **Professional** editions. See the [editions comparison](../vipm-editions-comparison.md) for details.
+[VIPM Free](../vipm-editions-comparison.md#available-editions){ .md-button .vipm-tier-pill .vipm-tier-free }

--- a/docs/.snippets/tier-pro.md
+++ b/docs/.snippets/tier-pro.md
@@ -1,3 +1,1 @@
-!!! note "VIPM Professional tier"
-
-    Available in **VIPM Professional** edition only. See the [editions comparison](../vipm-editions-comparison.md) for details.
+[VIPM Pro](../vipm-editions-comparison.md#available-editions){ .md-button .vipm-tier-pill .vipm-tier-pro }

--- a/docs/release-notes/2026.3.md
+++ b/docs/release-notes/2026.3.md
@@ -11,8 +11,6 @@ Many of the new features and capabilities are visible in the `vipm` command-line
 
 ## Software Bill of Materials (SBOM) wtih `vipm sbom` CLI Command
 
---8<-- "tier-free.md"
-
 Generate [CycloneDX](https://cyclonedx.org/) 1.5 SBOMs from LabVIEW projects, vipm.toml manifests, `.vipc`, or `.dragon` files. SBOMs include both VIPM and NI packages with enriched metadata, license identifiers, and cryptographic hashes — helping meet compliance requirements such as the EU Cyber Resilience Act and US Executive Order 14028.
 
 --8<-- "cra-compliance-help.md"
@@ -30,8 +28,6 @@ See the [SBOM documentation](../sbom/index.md) for a tutorial and workflow guida
 
 ## Scan Projects for Dependencies with `vipm sync` CLI Command
 
---8<-- "tier-free.md"
-
 Reconcile a `vipm.toml` manifest from the dependencies discovered in a LabVIEW project scan. This enables a workflow where you maintain `vipm.toml` as the source of truth — sync from your `.lvproj`, then generate SBOMs from the manifest without needing LabVIEW on your build machine.
 
 ```bash
@@ -42,8 +38,6 @@ vipm sync --from MyProject.lvproj --dry-run  # preview changes
 See the [`vipm sync` command reference](../cli/command-reference.md#vipm-sync) for full options.
 
 ## Lookup Package Metadata with `vipm info` CLI Command
-
---8<-- "tier-free.md"
 
 Look up metadata for any VIPM or NI package — name, version, description, vendor, license, and installed files. Supports both VIPM packages and NI packages via the `--nipm` flag.
 
@@ -77,8 +71,6 @@ Updated [Docker](../cli/docker.md) and [GitHub Actions](../cli/github-actions.md
 
 ## Cancel or Time-Bound Long-Running CLI Commands
 
---8<-- "tier-free.md"
-
 Long-running operations in the `vipm` command-line interface (CLI) can now be interrupted cleanly with **Ctrl+C** across the CLI, and `vipm sbom` and `vipm sync` additionally support the **`--timeout`** flag — useful when a project scan is taking longer than expected, or to guarantee a CI job cannot hang indefinitely.
 
 - **Ctrl+C handling (CLI).** Pressing Ctrl+C cancels the in-flight CLI operation cleanly rather than leaving the command in an indeterminate state. In addition to `vipm sbom` and `vipm sync`, this now also covers `vipm install`, `vipm cache update`, and `vipm refresh`.
@@ -86,8 +78,6 @@ Long-running operations in the `vipm` command-line interface (CLI) can now be in
 - **`--timeout` flag (CLI).** Sets a maximum wall-clock duration; the CLI command exits with a non-zero code if it exceeds the limit. Works alongside the existing `VIPM_TIMEOUT` environment variable. Applies to `vipm sbom` and `vipm sync`.
 
 ## Stricter Defaults for Project-Scanning CLI Commands
-
---8<-- "tier-free.md"
 
 `vipm sync` and `vipm sbom` now fail by default when they detect conditions that would produce incomplete or misleading output. Both failure modes are opt-out with a dedicated flag and expose the same per-entry detail on stderr when the flag is set.
 
@@ -98,16 +88,12 @@ Long-running operations in the `vipm` command-line interface (CLI) can now be in
 
 ## More Reliable `vipm.lock` with Dev-Dependencies
 
---8<-- "tier-free.md"
-
 `vipm.lock` now always reflects the full resolved dependency graph — both production and dev-dependencies — regardless of which `--dev` flags are passed. This matches the convention of other lock-file-based package managers (pip, poetry, npm, cargo) and ensures consistent installs across environments.
 
 - **`vipm install` always preserves dev-dependencies in `vipm.lock`.** Running `vipm install` without `--dev` no longer strips dev-dependencies from the lock file; the lock file remains complete.
 - **`vipm lock --dev` and `--no-dev` flags removed.** Since the lock file always includes dev-dependencies, these flags no longer have an effect and have been removed in this release. Remove them from any scripts that pass them. (`vipm lock` requires **VIPM Community** or higher.)
 
 ## Additional improvements
-
---8<-- "tier-free.md"
 
 - LabVIEW project scans run faster on large projects, so `vipm sync` and `vipm sbom` complete more quickly on sizeable `.lvproj` files.
 

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,38 @@
+/* Tier badge — compact, colored label appearing under a section heading.
+   Built on Material's .md-button so it's still a clickable link to the
+   editions-comparison page, but visually distinct from regular CTA buttons. */
+
+.md-typeset .md-button.vipm-tier-pill {
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.55rem;
+  font-weight: 700;
+  line-height: 1;
+  padding: 0.25rem 0.55rem;
+  border-radius: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  vertical-align: middle;
+  border: 1px solid transparent;
+}
+
+.md-typeset .md-button.vipm-tier-free {
+  background-color: #dbeafe;
+  color: #1e40af;
+}
+
+.md-typeset .md-button.vipm-tier-community {
+  background-color: #fed7aa;
+  color: #9a3412;
+}
+
+.md-typeset .md-button.vipm-tier-pro {
+  background-color: #dcfce7;
+  color: #166534;
+}
+
+.md-typeset .md-button.vipm-tier-pill:hover,
+.md-typeset .md-button.vipm-tier-pill:focus {
+  opacity: 0.85;
+  color: inherit;
+}

--- a/docs/vipm-editions-comparison.md
+++ b/docs/vipm-editions-comparison.md
@@ -8,9 +8,9 @@ To download VIPM and/or purchase a VIPM Professional License visit [vipm.io/get]
 
 The three primary VIPM editions are:
 
-- **VIPM Community**: Advanced features typically reserved for Pro, but restricted to non-commercial use only
-- **VIPM Free**: Basic version that is free for commercial use
-- **VIPM Pro**: The full-featured commercial version for professional development
+- [VIPM Community](#available-editions){ .md-button .vipm-tier-pill .vipm-tier-community } — Advanced features typically reserved for Pro, but restricted to non-commercial use only.
+- [VIPM Free](#available-editions){ .md-button .vipm-tier-pill .vipm-tier-free } — Basic version that is free for commercial use.
+- [VIPM Pro](#available-editions){ .md-button .vipm-tier-pill .vipm-tier-pro } — The full-featured commercial version for professional development.
 
 ## Legend
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,9 @@ extra:
     - icon: fontawesome/brands/discord
       link: https://discord.gg/uyXwAz4B63
 
+extra_css:
+  - stylesheets/extra.css
+
 markdown_extensions:
   - admonition
   - attr_list


### PR DESCRIPTION
## Why

The verbose tier-badge admonitions introduced in #85 take up significant vertical space (full Material admonition with header, body, and link line) and the default `note` icon doesn't read as a tier marker. Eight badges on the 2026.3 page also pushed actual content well below the fold.

Two problems to address:

1. **Visual weight.** Compact uppercase color pills convey "tier marker" at a glance and use ~1/8 the vertical space of an admonition.
2. **Information value.** "Free" features work in all editions, so a "Free" badge says the same thing as no-badge ("no restriction"). Under the *flag exceptions, not norms* UX principle, the 7 Free badges on 2026.3 were noise; the 1 Community badge carries real information.

Follow-up audit work (apply badges across the rest of the docs site) is tracked separately upstream.

## What landed

### Compact pill style (`docs/.snippets/tier-*.md`, `docs/stylesheets/extra.css`, `mkdocs.yml`)

Three snippets now produce a small uppercase colored pill instead of a multi-line admonition:

| Tier | Background | Text |
|---|---|---|
| VIPM Free | ![#dbeafe](https://placehold.co/15x15/dbeafe/dbeafe.png) `#dbeafe` | `#1e40af` |
| VIPM Community | ![#fed7aa](https://placehold.co/15x15/fed7aa/fed7aa.png) `#fed7aa` | `#9a3412` |
| VIPM Pro | ![#dcfce7](https://placehold.co/15x15/dcfce7/dcfce7.png) `#dcfce7` | `#166534` |

Built on Material's `.md-button` so the pill is a clickable link to `vipm-editions-comparison.md#available-editions`. Custom `.vipm-tier-pill` class scopes the pill styling so existing `.md-button` instances (Security page "Learn More", CRA-help snippet button) keep their default rectangular styling — verified locally.

CSS (`docs/stylesheets/extra.css`) wired in via a new `extra_css:` entry in `mkdocs.yml`.

### "Flag exceptions, not norms" applied to 2026.3 (`docs/release-notes/2026.3.md`)

- **Removed:** 7 `--8<-- "tier-free.md"` inclusions (SBOM, vipm sync, vipm info, Cancel, Stricter Defaults, vipm.lock, Additional improvements). These sections are all Free-tier; absence of a badge already conveys "no restriction."
- **Kept:** `--8<-- "tier-community.md"` on the NIPM section — the only place a tier-restriction badge carries real information.
- **Kept:** the two inline callouts within Free-tier sections — `vipm uninstall`/`vipm build` in the Cancel section and `vipm lock` in the vipm.lock section. These correctly flag per-bullet exceptions.

### Badges in editions-comparison page (`docs/vipm-editions-comparison.md`)

Replaces the bold tier names in the "Available Editions" bullet list with inline badge markdown so readers see each tier's visual identity inline with its description. Bullets use inline-direct markdown rather than `--8<--` snippet inclusion because pymdownx.snippets only processes its directive at the start of a line, not mid-line within a list item; the rendered output is identical to what the snippets produce.

## Test plan

- [x] `just build` passes; both post-build checks (release-notes table, report-a-problem redirect) green.
- [x] Visual review of `release-notes/2026.3/` and `vipm-editions-comparison/` confirms badges render as expected, fully centered, with per-tier colors.
- [x] Existing `.md-button` instances (Security page, CRA snippet) keep their rectangular styling — pill scoping verified.
- [x] All four badge inclusions resolve correctly to `vipm-editions-comparison/#available-editions`.