### PR TITLE
Correct --labview-bitness description: independent of --labview-version

### DIFF
--- a/data/vipm-public-cli.json
+++ b/data/vipm-public-cli.json
@@ -36,7 +36,7 @@
       "name": "labview_bitness",
       "long": "--labview-bitness",
       "value_name": "32|64",
-      "description": "Used in conjunction with --labview-version when there are multiple bitnesses of the same LabVIEW version installed",
+      "description": "Selects 32-bit or 64-bit LabVIEW. Can be supplied with or without --labview-version; complements a year resolved from any source",
       "defaults": [],
       "required": false,
       "multiple": false,


### PR DESCRIPTION
## Summary

The Global Options metadata in `data/vipm-public-cli.json` described `--labview-bitness` as "Used in conjunction with --labview-version when there are multiple bitnesses..." That wording implied the flag only made sense paired with `--labview-version`. The CLI's actual behavior is broader: `--labview-bitness` complements a year resolved from any source (CLI flag, `vipm.toml`, `.lvproj` LVVersion, or auto-detection), and can be supplied independently of `--labview-version`.

This PR updates the JSON description to match the actual behavior. The new wording is identical to the CLI's own clap help text on the flag.

## Why this matters

The Global Options table on the command reference page is generated from this JSON. The stale description was telling readers the flag was less general than it is — which would steer users away from valid usage like setting `--labview-bitness 32` against a `.lvproj` whose year comes from the file itself.

## Test plan

- [x] `data/vipm-public-cli.json` parses as valid JSON (verified via the existing data structure; the change is a single string value).
- [ ] Reviewer: confirm the rendered Global Options table picks up the new description after the next build.