### PR TITLE
docs(cli): modernize examples to use `vipm refresh`

### DIFF
--- a/dev-docs/cli-docs-improvement-proposal.md
+++ b/dev-docs/cli-docs-improvement-proposal.md
@@ -43,6 +43,7 @@ _Update the tables above each time we complete or add scope so this document sta
 | 2025-11-22 | Reduced duplicated examples across CLI docs | ✅ | Streamlined `docs/cli/index.md` and `docs/cli/docker.md`; both now point to the command reference instead of repeating full command walkthroughs |
 | 2025-11-22 | Clarified CLI index navigation | ✅ | Updated `docs/cli/index.md` Getting Started section to explicitly link to downstream topic pages |
 | 2025-11-22 | Synced CLI pages with command reference availability | ✅ | Updated `docs/cli/index.md`, `docs/cli/getting-started.md`, `docs/cli/docker.md`, and `docs/cli/github-actions.md` to reference the live command reference and current troubleshooting guidance |
+| 2026-05-13 | Replaced `vipm package-list-refresh` examples with `vipm refresh` | ✅ | Modernized tutorial, CI examples, and reference content across `docs/cli/command-reference.md`, `getting-started.md`, `github-actions.md`, `docker.md`, and `index.md` to use the canonical `vipm refresh` command. The command-reference section now uses the generated snippet (`_generated/commands/refresh.md`) from `data/vipm-public-cli.json`, matching the pattern adopted for other commands in #95 |
 
 ## Decision Register
 
@@ -134,7 +135,7 @@ docs/cli/
 │   ├── list.md                       # vipm list command
 │   ├── build.md                      # vipm build command
 │   ├── vipm-activate.md              # vipm activate command
-│   └── package-list-refresh.md       # vipm package-list-refresh command
+│   └── refresh.md                    # vipm refresh command
 │
 ├── guides/                           # Task-oriented guides
 │   ├── index.md                      # Guides overview
@@ -234,7 +235,7 @@ vipm install project.vipc
 ## Common Issues
 
 **Package not found**
-- Run `vipm package-list-refresh` first
+- Run `vipm refresh` first
 - Check package name spelling
 ```
 
@@ -242,7 +243,7 @@ vipm install project.vipc
 
 Create a streamlined getting-started.md with:
 1. Installation verification
-2. First command (package-list-refresh)
+2. First command (refresh)
 3. Installing your first package
 4. Listing installed packages
 5. Next steps

--- a/docs/cli/command-reference.md
+++ b/docs/cli/command-reference.md
@@ -43,7 +43,7 @@ Commands may additionally emit codes not listed here (e.g., authentication, netw
 | [`vipm uninstall`](#vipm-uninstall) | Remove packages from the selected LabVIEW installation. |
 | [`vipm list`](#vipm-list) | List installed packages or inspect a `.vipc`/`.dragon` file. |
 | [`vipm info`](#vipm-info) | Show metadata and installed files for a package. |
-| [`vipm package-list-refresh`](#vipm-package-list-refresh) | Refresh repository metadata (legacy command, still supported). |
+| [`vipm refresh`](#vipm-refresh) | Refresh all package sources (VIPM Desktop, CLI cache, NIPM feeds). |
 | [`vipm activate`](#vipm-activate) | Activate VIPM Pro using a serial number, name, and email. |
 | [`vipm build`](#vipm-build) | Build packages from `.vipb` specs or LabVIEW project build specs. |
 | [`vipm sbom`](#vipm-sbom) | Generate a CycloneDX SBOM from a project or manifest. |
@@ -86,7 +86,7 @@ Installing 2 packages
 
 ### Common Issues
 
-- **Package not found**: Run `vipm package-list-refresh` and verify the package ID at [vipm.io](https://www.vipm.io).
+- **Package not found**: Run `vipm refresh` and verify the package ID at [vipm.io](https://www.vipm.io).
 - **Wrong LabVIEW version**: Specify `--labview-version` and `--labview-bitness` to target the correct environment.
 
 ## `vipm uninstall`
@@ -190,34 +190,16 @@ Showing 5 packages matching "openg":
 - Combine multiple terms (e.g., `vipm search serial communication`) to narrow results.
 - Append `--refresh` to ensure the latest catalog data before searching in CI.
 
-## `vipm package-list-refresh`
+## `vipm refresh`
 
-Legacy command that refreshes VIPM's cached repository metadata. Still widely used in scripts.
+--8<-- "_generated/commands/refresh.md"
 
-### Syntax
-
-```bash
-vipm package-list-refresh [OPTIONS]
-```
-
-### Options
-
-| Option | Description |
-|--------|-------------|
-| `--timeout <seconds>` | Set how long VIPM waits for the refresh to finish (`-1` waits indefinitely). |
-| `--lv-version <YY.0>` | Old-style LabVIEW version selector (prefer `--labview-version`). |
-| `--show-progress` | Display a progress bar. |
+Refreshes every package source the CLI consults: VIPM Desktop's repository list, the CLI's local cache (repo indexes, specs, database), and any configured NIPM feeds. Use `--no-cache` or `--no-nipm` to skip individual sources, and `--force` to re-download even when a cached copy looks current.
 
 ### Example
 
 ```bash
-vipm package-list-refresh
-```
-
-Expected output:
-
-```
-✓ Package list refreshed successfully
+vipm refresh
 ```
 
 ### Common Issues

--- a/docs/cli/docker.md
+++ b/docs/cli/docker.md
@@ -77,10 +77,10 @@ Once inside a running container, use the same CLI commands described in the [CLI
   vipm activate --serial-number "$VIPM_SERIAL_NUMBER" --name "$VIPM_FULL_NAME" --email "$VIPM_EMAIL"
   ```
 
-- **Refresh metadata** before every install to avoid stale caches when containers are rebuilt frequently:
+- **Refresh package sources** before every install to avoid stale caches when containers are rebuilt frequently:
 
   ```bash
-  vipm package-list-refresh
+  vipm refresh
   ```
 
 - **Install packages or `.vipc` files`** just like on desktop. If you have multiple LabVIEW versions in the container image, pair your command with `--labview-version` (and `--labview-bitness` when needed).

--- a/docs/cli/getting-started.md
+++ b/docs/cli/getting-started.md
@@ -48,18 +48,12 @@ Expected output:
 
 Skip this step if you are using Community/Free features only.
 
-## Step 3 — Refresh Package Metadata
+## Step 3 — Refresh Package Sources
 
-Pull the latest package list so that installs succeed on the first try:
+Pull the latest data from every source the CLI consults — VIPM Desktop's repository list, the CLI cache, and NIPM feeds — so that installs succeed on the first try:
 
 ```bash
-vipm package-list-refresh
-```
-
-Expected output:
-
-```
-✓ Package list refreshed successfully
+vipm refresh
 ```
 
 Behind a proxy or on a restricted network? Configure proxy environment variables before running this command, or plan to sync from an internal VIPM repository.
@@ -85,7 +79,7 @@ To install everything defined in a `.vipc` configuration:
 vipm install path/to/project.vipc
 ```
 
-If a package cannot be found, rerun `vipm package-list-refresh` and verify the package name on [vipm.io](https://www.vipm.io) or in your `.vipc` file.
+If a package cannot be found, rerun `vipm refresh` and verify the package name on [vipm.io](https://www.vipm.io) or in your `.vipc` file.
 
 ## Step 5 — List Installed Packages
 
@@ -116,5 +110,5 @@ Add `--labview-version` to focus on a specific LabVIEW release if you have more 
 
 - **CLI not found**: Use the VIPM terminal shortcut installed with VIPM or add the install directory (for example, `C:/Program Files/JKI/VIPM` or `/usr/local/jki/vipm`) to your PATH.
 - **Activation fails**: Confirm the serial number, name, and email match your VIPM account exactly; rerun `vipm activate` after updating secrets or environment variables.
-- **Package install fails**: Refresh metadata (`vipm package-list-refresh`) and double-check the package ID; add `--labview-version` when multiple LabVIEW versions are installed.
+- **Package install fails**: Refresh package sources (`vipm refresh`) and double-check the package ID; add `--labview-version` when multiple LabVIEW versions are installed.
 - **Network issues**: Configure proxy variables (`http_proxy`, `https_proxy`) or use an internal repository mirror if the build machine cannot reach `vipm.io`.

--- a/docs/cli/github-actions.md
+++ b/docs/cli/github-actions.md
@@ -80,8 +80,8 @@ jobs:
             --name "${{ secrets.VIPM_FULL_NAME }}" \
             --email "${{ secrets.VIPM_EMAIL }}"
       
-      - name: Refresh package list
-        run: vipm package-list-refresh
+      - name: Refresh package sources
+        run: vipm refresh
       
       - name: Install project dependencies
         run: vipm install -y project.vipc
@@ -164,8 +164,8 @@ jobs:
             --name "${{ secrets.VIPM_FULL_NAME }}" \
             --email "${{ secrets.VIPM_EMAIL }}"
       
-      - name: Refresh package list
-        run: vipm package-list-refresh
+      - name: Refresh package sources
+        run: vipm refresh
       
       - name: Install dependencies
         run: vipm install -y project.vipc
@@ -237,7 +237,7 @@ If activation fails in CI:
 ### Package Installation Failures
 
 If package installation fails:
-- Run `vipm package-list-refresh` before installing packages
+- Run `vipm refresh` before installing packages
 - Check that package names are correct (case-sensitive)
 - Verify LabVIEW version compatibility
 

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -14,8 +14,8 @@ Use these quick snippets to verify your environment, then jump to the [CLI Comma
 # Activate VIPM Pro (optional)
 
 
-# Refresh package list so installs see the latest metadata
-vipm package-list-refresh
+# Refresh package sources so installs see the latest metadata
+vipm refresh
 
 # Install packages by name or from a .vipc file
 vipm install oglib_boolean oglib_numeric


### PR DESCRIPTION
The canonical command for refreshing all package sources is `vipm refresh` (covers VIPM Desktop, CLI cache, and NIPM feeds), but several user-facing pages still teach `vipm package-list-refresh` — including the Step 3 of the getting-started tutorial, copy-pasteable CI workflow examples, and a dedicated command-reference section. This brings those pages in line with the canonical command so users following along get the right one.

## Changes

- `docs/cli/command-reference.md` — Quick Look row, `vipm install` Common Issues note, and the dedicated section. The section now uses the generated-snippet pattern `--8<-- "_generated/commands/refresh.md"` (sourced from `data/vipm-public-cli.json`), matching the pattern used by other commands.
- `docs/cli/getting-started.md` — Step 3 heading and content; "If a package cannot be found" note; Quick Troubleshooting Tips bullet.
- `docs/cli/github-actions.md` — Two workflow examples and the troubleshooting bullet.
- `docs/cli/docker.md` — Container-setup example and surrounding bullet text.
- `docs/cli/index.md` — Intro example.
- `dev-docs/cli-docs-improvement-proposal.md` — Progress log row recording the modernization; forward-looking directory tree and example content updated to use `refresh`.

## Test plan

- [x] `just check` passes (`ruff format --check` + `ruff check` + `pytest`: 22 passed)
- [x] `just build` passes (snippet generation + Zensical build + post-build validators all green)
- [x] Reviewer skims the rendered `/cli/command-reference/` `vipm refresh` section
- [x] Reviewer skims the rendered `/cli/getting-started/` Step 3 wording