### PR TITLE
Expand 2026.3 release notes for vipm-cli updates; refresh public CLI metadata

### DIFF
--- a/data/vipm-public-cli.json
+++ b/data/vipm-public-cli.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.0-public",
   "cli_version": "dev",
-  "generated_on": "2026-05-08",
+  "generated_on": "2026-05-13",
   "global_options": [
     {
       "name": "refresh",
@@ -379,7 +379,7 @@
     },
     {
       "name": "build",
-      "description": "Builds project artifacts from various sources",
+      "description": "Builds project artifacts from various sources (.lvproj and vipm.toml builds require LabVIEW 2024 and newer)",
       "access": {
         "tier": "community",
         "community_requires_public_repo": true
@@ -521,6 +521,22 @@
           "conflicts_with": [
             "no_deps"
           ]
+        },
+        {
+          "name": "allow_package_drift",
+          "long": "--allow-package-drift",
+          "value_name": "ALLOW_PACKAGE_DRIFT",
+          "description": "Allow builds to proceed when installed packages disagree with vipm.toml / vipm.lock. Verification still runs but failures are emitted as warnings instead of errors",
+          "defaults": [],
+          "required": false,
+          "multiple": false,
+          "possible_values": [
+            "true",
+            "false"
+          ],
+          "aliases": [],
+          "visible_aliases": [],
+          "conflicts_with": []
         }
       ],
       "subcommands": []
@@ -1158,13 +1174,29 @@
           "aliases": [],
           "visible_aliases": [],
           "conflicts_with": []
+        },
+        {
+          "name": "nipm",
+          "long": "--nipm",
+          "value_name": "NIPM",
+          "description": "Resolve the named package in the NIPM namespace. The canonical contract (see `docs/general/package-manager-filter.md`) specifies this form; the CLI returns NOT_IMPLEMENTED until the NIPM uninstall path is built. Not valid on VIPC or Dragon inputs, which are VIPM-only by format",
+          "defaults": [],
+          "required": false,
+          "multiple": false,
+          "possible_values": [
+            "true",
+            "false"
+          ],
+          "aliases": [],
+          "visible_aliases": [],
+          "conflicts_with": []
         }
       ],
       "subcommands": []
     },
     {
       "name": "sbom",
-      "description": "Generate a Software Bill of Materials",
+      "description": "Generate a Software Bill of Materials (supports LabVIEW 2024 and newer)",
       "access": {
         "tier": "free",
         "community_requires_public_repo": true
@@ -1449,7 +1481,7 @@
     },
     {
       "name": "sync",
-      "description": "Synchronize vipm.toml with dependencies discovered by scanning a project",
+      "description": "Synchronize vipm.toml with dependencies discovered by scanning a project (supports LabVIEW 2024 and newer)",
       "access": {
         "tier": "free",
         "community_requires_public_repo": true

--- a/docs/release-notes/2026.3.md
+++ b/docs/release-notes/2026.3.md
@@ -82,7 +82,7 @@ Long-running operations in the `vipm` command-line interface (CLI) can now be in
 `vipm sync` and `vipm sbom` now fail by default when they detect conditions that would produce incomplete or misleading output. Both failure modes are opt-out with a dedicated flag and expose the same per-entry detail on stderr when the flag is set.
 
 - **Missing referenced files.** When a LabVIEW project references files that are not on disk, the command aborts with exit code `18` instead of printing a warning and returning success. Pass `--allow-missing-files` to restore the previous behavior — a warning listing each missing reference is printed to stderr, and the command proceeds with whatever could be scanned.
-- **Installed-package drift (`vipm sbom`).** When installed packages disagree with the project's declared state in `vipm.toml` or `vipm.lock`, `vipm sbom` aborts with exit code `17`. Pass `--allow-package-drift` to override — a warning listing the drifted packages is printed to stderr, and the SBOM reflects installed versions.
+- **Installed-package drift (`vipm sbom`, `vipm build`).** When installed packages disagree with the project's declared state in `vipm.toml` or `vipm.lock`, the command aborts with exit code `17`. Pass `--allow-package-drift` to override — a warning listing the drifted packages is printed to stderr, and the command proceeds (the SBOM or build reflects installed versions).
 
 **Migration note for automation.** Scripts that previously treated exit code `0` as "output produced successfully" may need to either add the appropriate `--allow-*` flag or fix the underlying condition (run `vipm install` to reconcile drift; fix the project's file references). See the updated [`vipm sbom`](../cli/command-reference.md#vipm-sbom) and [`vipm sync`](../cli/command-reference.md#vipm-sync) references for full details.
 
@@ -93,8 +93,21 @@ Long-running operations in the `vipm` command-line interface (CLI) can now be in
 - **`vipm install` always preserves dev-dependencies in `vipm.lock`.** Running `vipm install` without `--dev` no longer strips dev-dependencies from the lock file; the lock file remains complete.
 - **`vipm lock --dev` and `--no-dev` flags removed.** Since the lock file always includes dev-dependencies, these flags no longer have an effect and have been removed in this release. Remove them from any scripts that pass them. (`vipm lock` requires **VIPM Community** or higher.)
 
+## LabVIEW Version Selection
+
+Selecting which LabVIEW version VIPM uses is now more flexible and predictable.
+
+- **Workspace-local override.** Set the LabVIEW version for a single workspace via `vipm.toml` without affecting the global default. This lets a project pin a specific LabVIEW version for its dependencies, builds, and SBOMs, regardless of the user's globally-selected LabVIEW.
+- **Bitness preferences honored consistently.** When you specify `--labview-bitness` on the command line or set the LabVIEW bitness in `vipm.toml`, that preference is now consistently respected when VIPM picks the LabVIEW version to use.
+
 ## Additional improvements
 
 - LabVIEW project scans run faster on large projects, so `vipm sync` and `vipm sbom` complete more quickly on sizeable `.lvproj` files.
+- `vipm search`, `vipm build`, and `vipm sbom` reliably find and use the active `vipm.toml`.
+- `vipm sbom` on `.dragon` files supports both VIPM and NI Package Manager packages again.
+- `vipm about` shows one combined line when Desktop and CLI versions match, and warns when they differ.
+- Passing `--vipm` or `--nipm` to a command that doesn't accept them now produces a clear, consistent error.
+- A non-VIPM TOML file named `vipm.toml` is now rejected with a clear error rather than partially parsed.
+- `vipm.lock` package ordering is now stable across machines and platforms, so `vipm lock` no longer produces spurious diffs.
 
 --8<-- "need-help.md"


### PR DESCRIPTION
## Why

VIPM 2026 Q3 (Preview) has new capabilities and bug fixes that need to land in the user-facing release notes and in the CLI metadata that drives the docs site's command reference.

## Changes

### `docs/release-notes/2026.3.md`

- New section: **LabVIEW Version Selection** (workspace-local override; consistent honoring of `--labview-bitness` / `vipm.toml` bitness).
- Updated the **Installed-package drift** bullet under "Stricter Defaults for Project-Scanning CLI Commands" — drift detection now applies to `vipm build` in addition to `vipm sbom`.
- Six new bullets in **Additional improvements**:
    - `vipm search`, `vipm build`, and `vipm sbom` now reliably find and use the active `vipm.toml`
    - `vipm sbom` on `.dragon` files supports both VIPM and NI Package Manager packages again
    - `vipm about` shows one combined line when Desktop and CLI versions match, and warns when they differ
    - Clearer errors when `--vipm` / `--nipm` are passed to commands that don't accept them
    - Rejection of files named `vipm.toml` that don't actually contain VIPM configuration
    - Stable `vipm.lock` package ordering across machines and platforms

### `data/vipm-public-cli.json`

Regenerated to reflect the latest `vipm` CLI surface. Substantive changes vs. the previous snapshot:

- `vipm build` description now mentions LabVIEW 2024+ requirement and gains a new `--allow-package-drift` option.
- `vipm uninstall` gains a `--nipm` option (currently a NOT_IMPLEMENTED stub — surfaced in the option's own help text).
- `vipm sbom` and `vipm sync` descriptions now mention LabVIEW 2024+ requirement.