### PR TITLE
docs(vipm-toml): add Workspace-Local Configuration page for .vipm/config.toml

### DIFF
--- a/docs/release-notes/2026.3.md
+++ b/docs/release-notes/2026.3.md
@@ -97,7 +97,7 @@ Long-running operations in the `vipm` command-line interface (CLI) can now be in
 
 Selecting which LabVIEW version VIPM uses is now more flexible and predictable.
 
-- **Workspace-local override.** Set the LabVIEW version for a single workspace via `vipm.toml` without affecting the global default. This lets a project pin a specific LabVIEW version for its dependencies, builds, and SBOMs, regardless of the user's globally-selected LabVIEW.
+- **Workspace-local override (`.vipm/config.toml`).** Drop a `.vipm/config.toml` next to your project's `vipm.toml` to set a different LabVIEW year and/or bitness for **your local checkout only** — without editing the team's `vipm.toml` and without retyping `--labview-version` on every command. Useful when you haven't installed the team-pinned LabVIEW year yet, when CI runners have different LabVIEW versions than developers, or when you're preparing a version bump. The file is per-developer; add `.vipm/` to your repo's `.gitignore`. See [Workspace-Local Configuration](../vipm-toml/workspace-local-config.md) for the full guide.
 - **Bitness preferences honored consistently.** When you specify `--labview-bitness` on the command line or set the LabVIEW bitness in `vipm.toml`, that preference is now consistently respected when VIPM picks the LabVIEW version to use.
 
 ## Additional improvements

--- a/docs/vipm-toml/getting-started.md
+++ b/docs/vipm-toml/getting-started.md
@@ -97,6 +97,9 @@ version = "0.1.0"
 labview-version = "2024"
 ```
 
+!!! tip "Per-developer LabVIEW version override"
+    The `[project].labview-version` field is the team's pinned version, shared via git. If you need to run commands against a different LabVIEW year locally — without editing the shared file — create a personal `.vipm/config.toml`. See [Workspace-Local Configuration](workspace-local-config.md).
+
 ---
 
 ## Managing Dependencies
@@ -196,7 +199,7 @@ When run without arguments, `vipm install` searches for manifest files in this o
 2. `.dragon` file
 3. `.vipc` file
 
-The `labview-version` from `vipm.toml` is used automatically when installing.
+The `labview-version` from `vipm.toml` is used automatically when installing. To override for your local checkout only — without editing the shared file — see [Workspace-Local Configuration](workspace-local-config.md).
 
 ---
 

--- a/docs/vipm-toml/index.md
+++ b/docs/vipm-toml/index.md
@@ -76,5 +76,6 @@ builds/my_library/MyLibrary.lvlib
 ## Next Steps
 
 - Read through **[the Getting Started guide](getting-started.md)** and follow the step-by-step instructions for using `vipm.toml` for your labview project dependencies, builds, and CI/CD workflow automations.
+- Need to use a different LabVIEW version on your machine than the team has pinned? See **[Workspace-Local Configuration](workspace-local-config.md)** for the per-developer `.vipm/config.toml` override.
 
 --8<-- "need-help.md"

--- a/docs/vipm-toml/workspace-local-config.md
+++ b/docs/vipm-toml/workspace-local-config.md
@@ -1,0 +1,164 @@
+---
+title: Workspace-Local Config
+---
+
+# Workspace-Local Configuration (`.vipm/config.toml`)
+
+!!! warning "Preview Feature"
+    Workspace-local configuration requires **VIPM Desktop 2026 Q3 Preview** or later. This feature is not available in stable releases. See the [Preview page](../preview.md) for installation instructions.
+
+`.vipm/config.toml` is a **per-developer, non-committed** companion to `vipm.toml`. It lets you override the LabVIEW version your local commands use — without editing the team's shared `vipm.toml` and without retyping `--labview-version` on every invocation.
+
+The team's `vipm.toml` and your personal `.vipm/config.toml` are two different things:
+
+- **`vipm.toml`** is the project's team contract — committed to the repo, shared across the team.
+- **`.vipm/config.toml`** is your personal override — local to your checkout, never committed.
+
+## When to use it
+
+- **You haven't installed the team's pinned LabVIEW year yet.** The team's `vipm.toml` declares `labview-version = "2024"`, but you're still on LabVIEW 2023 locally. Point `.vipm/config.toml` at 2023 so `vipm install`, `vipm sbom`, etc. run against your installed year — without touching the shared file.
+- **CI runner / dev-machine drift.** A CI runner has a different set of installed LabVIEW versions than the developer who authored `vipm.toml`. The runner's `.vipm/config.toml` selects what's actually there.
+- **Compatibility review.** You're reviewing a PR and want to validate the project against a LabVIEW year other than the one the author declared.
+- **Version-bump preparation.** You're about to bump the team's `labview-version` in `vipm.toml` and want to verify locally first.
+
+## File location and shape
+
+`.vipm/config.toml` lives in a `.vipm/` directory **next to your project's `vipm.toml`**:
+
+```
+my-project/
+├── vipm.toml          # team-committed
+├── .vipm/
+│   └── config.toml    # per-developer; gitignored
+└── ...
+```
+
+The file is a small TOML overlay of `vipm.toml`'s `[project]` section:
+
+```toml
+[project]
+labview-version = "2023"
+labview-bitness = 64
+```
+
+A `.vipm/` directory in any other location is ignored. The override is consulted only when colocated with the `vipm.toml` that VIPM discovered for your command.
+
+## Allowed keys
+
+Two keys, both optional:
+
+| Key | Type | Purpose |
+|-----|------|---------|
+| `[project].labview-version` | string (year, e.g. `"2024"`) | Year to use for this workspace |
+| `[project].labview-bitness` | integer (`32` or `64`) | Bitness to use for this workspace |
+
+Any other key — a different `[project]` field, or any other table — is rejected. For example, this file:
+
+```toml
+[project]
+name = "my-project"           # ← not allowed in .vipm/config.toml
+```
+
+produces an error and exits with code `2`. Only the LabVIEW year and bitness are configurable here; everything else belongs in `vipm.toml`.
+
+## Precedence
+
+When VIPM picks a LabVIEW version for a command, it consults sources in this order — the **first** source that yields a value wins:
+
+1. `--labview-version` / `--labview-bitness` CLI flags
+2. **`.vipm/config.toml`** (this file)
+3. `vipm.toml` `[project].labview-version` / `labview-bitness`
+4. Input-file metadata (`.lvproj` `LVVersion`, `.dragon` / `.vipc` target, etc.)
+5. Auto-detect from installed LabVIEW
+
+`labview-version` and `labview-bitness` are resolved **independently**. For example, with the override file above and a `vipm.toml` that declares `labview-version = "2024"`:
+
+- `vipm install` → uses LabVIEW 2023 (64-bit). The override's year wins over `vipm.toml`'s.
+- `vipm install --labview-version 2025` → uses LabVIEW 2025 (64-bit). The CLI flag's year wins over the override's. Bitness still comes from the override since the CLI did not provide one.
+
+## Field independence
+
+You can override only the year, only the bitness, or both.
+
+**Override the year only:**
+
+```toml
+[project]
+labview-version = "2023"
+```
+
+Bitness then comes from `vipm.toml` (or its default of 64).
+
+**Override the bitness only:**
+
+```toml
+[project]
+labview-bitness = 32
+```
+
+Year then comes from `vipm.toml` (or a lower layer).
+
+**Override both:**
+
+```toml
+[project]
+labview-version = "2023"
+labview-bitness = 32
+```
+
+!!! tip
+    When the target year/bitness combination on your machine differs from `vipm.toml` in **both** dimensions, set both keys explicitly. Bitness-only overrides work, but if the year resolved from a lower layer isn't installed in your chosen bitness, the resulting error is less specific than if you'd named the combination directly in `.vipm/config.toml`.
+
+## Gitignore convention
+
+`.vipm/` is per-developer state. Don't commit it. Add this to your repo's `.gitignore`:
+
+```gitignore
+.vipm/
+```
+
+Each developer's `.vipm/config.toml` then stays local to their checkout, and the team's `vipm.toml` remains the single committed source of project configuration.
+
+## Errors
+
+| Scenario | Exit code | Behavior |
+|----------|-----------|----------|
+| Override points at an uninstalled year/bitness | `4` | Fails fast. The error names `.vipm/config.toml` so you know where to fix it. |
+| Unknown key in `.vipm/config.toml` | `2` | Rejected at parse time; error names the unknown key. |
+| Malformed TOML | `2` | Rejected at parse time. |
+| Override's year is older than the command's minimum LabVIEW year | `20` | Some commands have a minimum LabVIEW year (e.g., `vipm build` requires LabVIEW 2024+); the error reports the resolved version and the override path. |
+| Override's year is newer than the CLI's supported window | `19` | Rare; surfaces only if you override to a year past the CLI's upper bound. |
+
+See the [CLI command reference](../cli/command-reference.md) for the full exit-code taxonomy.
+
+## Complete example
+
+A typical project where the team is on LabVIEW 2024 64-bit, but you're temporarily running LabVIEW 2023 32-bit:
+
+```
+my-project/
+├── vipm.toml          # team: labview-version = "2024", labview-bitness = 64
+├── .vipm/
+│   └── config.toml    # you:  labview-version = "2023", labview-bitness = 32
+└── .gitignore         # contains: .vipm/
+```
+
+`my-project/.vipm/config.toml`:
+
+```toml
+[project]
+labview-version = "2023"
+labview-bitness = 32
+```
+
+Running `vipm install` from inside `my-project/`:
+
+```
+$ vipm install
+Using LabVIEW 2023 (32-bit) from workspace override (./.vipm/config.toml)
+... installs dependencies for LabVIEW 2023 (32-bit) ...
+```
+
+A teammate who has not created their own `.vipm/config.toml` continues to see LabVIEW 2024 (64-bit) per the team's `vipm.toml`. The shared file does not change.
+
+--8<-- "need-help.md"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -70,6 +70,7 @@ nav:
     - Using vipm.toml Files:
       - vipm-toml/index.md
       - vipm-toml/getting-started.md
+      - vipm-toml/workspace-local-config.md
       - vipm-toml/nipm.md
     - Building Packages:
       - building-packages/index.md


### PR DESCRIPTION
## Summary

Adds a public docs page for the per-developer `.vipm/config.toml` workspace-local LabVIEW version override that shipped in the 2026 Q3 Preview. Until now there's been no place in the public docs for end users to learn how to use it — only a one-bullet mention in the 2026 Q3 release notes (which, as it turns out, was describing the wrong thing; see below).

## Changes

### New page

**`docs/vipm-toml/workspace-local-config.md`** — full guide covering:

- **What it is / when to use it.** Explicit framing of `vipm.toml` (team-committed) vs. `.vipm/config.toml` (per-developer); four named use cases (uninstalled team-pinned year, CI/dev-machine drift, compatibility review, version-bump preparation).
- **File location and shape.** Co-located with `vipm.toml`; minimal TOML example; directory-layout diagram.
- **Allowed keys.** Strict `labview-version` / `labview-bitness` allowlist; explicit rejection behavior for other keys.
- **Precedence.** The five-layer chain (CLI > workspace-local > `vipm.toml` > input-file > auto-detect); worked example showing year + bitness resolving independently.
- **Field independence.** Year-only, bitness-only, or both — with a tip on when to set both explicitly.
- **Gitignore convention.** Recommends adding `.vipm/` to the repo's `.gitignore`.
- **Errors.** Exit-code table for the override-specific failures (uninstalled year/bitness → 4 with override path named; unknown key → 2; malformed TOML → 2; year-too-old → 20; year-too-new → 19).
- **Complete example.** Side-by-side `vipm.toml` vs. `.vipm/config.toml`, the directory layout, and the resulting `vipm install` output.

### Navigation and cross-links

- `mkdocs.yml` — new entry under **Using vipm.toml Files**, between `getting-started.md` and `nipm.md`.
- `docs/vipm-toml/index.md` — Next-Steps bullet pointing at the new page.
- `docs/vipm-toml/getting-started.md` — admonition tip after the `[project].labview-version` example; inline pointer in the "Installing Dependencies" section.

### Release-notes correction

**`docs/release-notes/2026.3.md`** — the **LabVIEW Version Selection** section previously contained:

> **Workspace-local override.** Set the LabVIEW version for a single workspace via `vipm.toml` without affecting the global default. […]

That bullet was labeled "Workspace-local override" but the prose described setting `labview-version` *in `vipm.toml`* — the long-standing team-committed field, not the new `.vipm/config.toml` overlay. Users reading those release notes wouldn't learn the new feature exists. Rewrites the bullet to name the actual new file, link to the new docs page, and call out the gitignore convention. The adjacent "Bitness preferences honored consistently" bullet is unchanged.

## Test plan

- [x] `just build` clean — `/vipm-toml/workspace-local-config/` appears in the build output; post-build link checker passes.
- [x] `just check` clean — ruff format + lint + 22 tests pass.
- [ ] Local preview confirms the page renders with correct headings, tables, and admonitions.
- [ ] All four new cross-links resolve in the preview (Next-Steps, getting-started tip, getting-started inline, release-notes).