### PR TITLE
Document vipm search NIPM support and refresh public CLI metadata

### DIFF
--- a/data/vipm-public-cli.json
+++ b/data/vipm-public-cli.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.0-public",
   "cli_version": "dev",
-  "generated_on": "2026-05-13",
+  "generated_on": "2026-05-14",
   "global_options": [
     {
       "name": "refresh",
@@ -44,27 +44,6 @@
       "aliases": [],
       "visible_aliases": [],
       "conflicts_with": []
-    },
-    {
-      "name": "json",
-      "long": "--json",
-      "value_name": "JSON",
-      "description": "Output in JSON format",
-      "defaults": [],
-      "required": false,
-      "multiple": false,
-      "possible_values": [
-        "true",
-        "false"
-      ],
-      "aliases": [],
-      "visible_aliases": [],
-      "conflicts_with": [],
-      "access": {
-        "tier": "professional",
-        "experimental": true,
-        "community_requires_public_repo": false
-      }
     },
     {
       "name": "color",
@@ -1106,7 +1085,7 @@
           "name": "limit",
           "long": "--limit",
           "value_name": "LIMIT",
-          "description": "Limit the number of packages shown (default: 10)",
+          "description": "Limit the number of packages shown per manager (default: 10). When both VIPM and NIPM contribute, each section is capped independently — total output can be up to 2× this value",
           "defaults": [],
           "required": false,
           "multiple": false,
@@ -1114,6 +1093,78 @@
           "aliases": [],
           "visible_aliases": [],
           "conflicts_with": []
+        },
+        {
+          "name": "vipm",
+          "long": "--vipm",
+          "value_name": "VIPM",
+          "description": "Include only VIPM packages",
+          "defaults": [],
+          "required": false,
+          "multiple": false,
+          "possible_values": [
+            "true",
+            "false"
+          ],
+          "aliases": [],
+          "visible_aliases": [],
+          "conflicts_with": [
+            "no_vipm"
+          ]
+        },
+        {
+          "name": "nipm",
+          "long": "--nipm",
+          "value_name": "NIPM",
+          "description": "Include only NIPM packages",
+          "defaults": [],
+          "required": false,
+          "multiple": false,
+          "possible_values": [
+            "true",
+            "false"
+          ],
+          "aliases": [],
+          "visible_aliases": [],
+          "conflicts_with": [
+            "no_nipm"
+          ]
+        },
+        {
+          "name": "no_vipm",
+          "long": "--no-vipm",
+          "value_name": "NO_VIPM",
+          "description": "Exclude VIPM packages from results",
+          "defaults": [],
+          "required": false,
+          "multiple": false,
+          "possible_values": [
+            "true",
+            "false"
+          ],
+          "aliases": [],
+          "visible_aliases": [],
+          "conflicts_with": [
+            "vipm"
+          ]
+        },
+        {
+          "name": "no_nipm",
+          "long": "--no-nipm",
+          "value_name": "NO_NIPM",
+          "description": "Exclude NIPM packages from results",
+          "defaults": [],
+          "required": false,
+          "multiple": false,
+          "possible_values": [
+            "true",
+            "false"
+          ],
+          "aliases": [],
+          "visible_aliases": [],
+          "conflicts_with": [
+            "nipm"
+          ]
         }
       ],
       "subcommands": []

--- a/docs/release-notes/2026.3.md
+++ b/docs/release-notes/2026.3.md
@@ -43,6 +43,12 @@ Look up metadata for any VIPM or NI package — name, version, description, vend
 
 See the [`vipm info` command reference](../cli/command-reference.md#vipm-info) for full options.
 
+## Search VIPM and NI Packages with `vipm search` CLI Command
+
+`vipm search` now finds NI Package Manager (NIPM) packages alongside VIPM packages, with the same filter controls as other multi-PM commands. Both managers are included by default; use `--vipm` or `--nipm` to scope results to one, or `--no-vipm` / `--no-nipm` to exclude one.
+
+See the [`vipm search` command reference](../cli/command-reference.md#vipm-search) for full options.
+
 ## NI Package (NIPM) Support in `vipm.toml`
 
 --8<-- "tier-community.md"


### PR DESCRIPTION
Documents the new NIPM-in-search capability so users discover it in the 2026 Q3 Preview release notes, and refreshes the public CLI metadata snapshot consumed by the docs site so it reflects the current public surface.

## Changes

- New `## Search VIPM and NI Packages with \`vipm search\` CLI Command` section in `docs/release-notes/2026.3.md`, placed alongside the existing `vipm info` capability section since both are package-lookup commands.
- Regenerated `data/vipm-public-cli.json`:
    - Adds `--vipm`, `--nipm`, `--no-vipm`, `--no-nipm` filter flags to `vipm search`.
    - Updates `vipm search --limit` description to clarify per-manager semantics (each manager capped independently).
    - Drops the experimental `--json` global option from the documented public surface — it is intentionally not part of the stable public API.

## Test plan

- [ ] `just build` succeeds locally
- [ ] Rendered `2026.3` release-notes page shows the new section under `vipm info`