### PR TITLE
docs(cli): drop --refresh flag references

### DIFF
--- a/data/vipm-public-cli.json
+++ b/data/vipm-public-cli.json
@@ -4,22 +4,6 @@
   "generated_on": "2026-05-14",
   "global_options": [
     {
-      "name": "refresh",
-      "long": "--refresh",
-      "value_name": "REFRESH",
-      "description": "Force a refresh of VIPM's package list before performing the operation",
-      "defaults": [],
-      "required": false,
-      "multiple": false,
-      "possible_values": [
-        "true",
-        "false"
-      ],
-      "aliases": [],
-      "visible_aliases": [],
-      "conflicts_with": []
-    },
-    {
       "name": "labview_version",
       "long": "--labview-version",
       "value_name": "YYYY",

--- a/docs/cli/command-reference.md
+++ b/docs/cli/command-reference.md
@@ -188,7 +188,7 @@ Showing 5 packages matching "openg":
 ### Tips
 
 - Combine multiple terms (e.g., `vipm search serial communication`) to narrow results.
-- Append `--refresh` to ensure the latest catalog data before searching in CI.
+- Run `vipm refresh` first to ensure the latest catalog data before searching in CI.
 
 ## `vipm refresh`
 


### PR DESCRIPTION
## Summary

The global `--refresh` flag is no longer part of the CLI surface. The dedicated `vipm refresh` command is the canonical way to update package metadata (VIPM Desktop repos, the CLI cache, and NIPM feeds), and it covers all three sources rather than only VIPM Desktop's repository list.

This PR drops the now-incorrect `--refresh` references from the docs:

- `docs/cli/command-reference.md` — the search-page CI tip now recommends `vipm refresh` as a separate step.
- `data/vipm-public-cli.json` — the `refresh` entry is removed from `global_options` so the auto-generated global-options snippet no longer documents the flag.

## Test plan

- [ ] CI: `just build` regenerates snippets cleanly with the updated source-of-truth JSON.
- [ ] Manual: rendered command-reference page no longer recommends `--refresh` anywhere.