### PR TITLE
Adjust VIPM 2026 Q3 notes

### DIFF
--- a/docs/release-notes/2026.3.md
+++ b/docs/release-notes/2026.3.md
@@ -114,7 +114,6 @@ Selecting which LabVIEW version VIPM uses is now more flexible and predictable.
 - `vipm about` shows one combined line when Desktop and CLI versions match, and warns when they differ.
 - Preview CLI builds can show their activation expiration in `vipm about`, and `VIPM_COMMUNITY_EDITION=false` or `0` no longer enables Community Edition accidentally.
 - `vipm refresh` is now the explicit way to refresh package indexes before running another command. The former global `--refresh` flag has been removed, and stale-index error hints now point to `vipm refresh`.
-- Repository detection ignores empty `.git` directories, so Community Edition access checks use the actual Git repository instead of stray temporary folders.
 - Passing `--vipm` or `--nipm` to a command that doesn't accept them now produces a clear, consistent error.
 - A non-VIPM TOML file named `vipm.toml` is now rejected with a clear error rather than partially parsed.
 - `vipm.lock` package ordering is now stable across machines and platforms, so `vipm lock` no longer produces spurious diffs.


### PR DESCRIPTION
Superseded by a direct release-note history rewrite.