### PR TITLE
Update 2026 Q3 release notes and public CLI metadata

### DIFF
--- a/data/vipm-public-cli.json
+++ b/data/vipm-public-cli.json
@@ -30,6 +30,27 @@
       "conflicts_with": []
     },
     {
+      "name": "json",
+      "long": "--json",
+      "value_name": "JSON",
+      "description": "Output in JSON format",
+      "defaults": [],
+      "required": false,
+      "multiple": false,
+      "possible_values": [
+        "true",
+        "false"
+      ],
+      "aliases": [],
+      "visible_aliases": [],
+      "conflicts_with": [],
+      "access": {
+        "tier": "professional",
+        "experimental": true,
+        "community_requires_public_repo": false
+      }
+    },
+    {
       "name": "color",
       "long": "--color-mode",
       "value_name": "COLOR_MODE",
@@ -1981,6 +2002,48 @@
         }
       ],
       "subcommands": []
+    },
+    {
+      "name": "labview",
+      "description": "LabVIEW-related queries",
+      "access": {
+        "tier": "professional",
+        "experimental": true,
+        "community_requires_public_repo": true
+      },
+      "arguments": [],
+      "options": [],
+      "subcommands": [
+        {
+          "name": "list",
+          "description": "List LabVIEW installations discovered natively on the host",
+          "access": {
+            "tier": "professional",
+            "experimental": true,
+            "community_requires_public_repo": true
+          },
+          "arguments": [],
+          "options": [
+            {
+              "name": "running",
+              "long": "--running",
+              "value_name": "RUNNING",
+              "description": "Only list installations that currently have a running instance",
+              "defaults": [],
+              "required": false,
+              "multiple": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "aliases": [],
+              "visible_aliases": [],
+              "conflicts_with": []
+            }
+          ],
+          "subcommands": []
+        }
+      ]
     }
   ]
 }

--- a/data/vipm-public-cli.json
+++ b/data/vipm-public-cli.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.0-public",
   "cli_version": "dev",
-  "generated_on": "2026-05-14",
+  "generated_on": "2026-05-27",
   "global_options": [
     {
       "name": "labview_version",
@@ -65,7 +65,7 @@
       "name": "show_progress",
       "long": "--show-progress",
       "value_name": "SHOW_PROGRESS",
-      "description": "Show real-time progress from VIPM Desktop during operations",
+      "description": "Force the real-time progress bar on. Progress is shown automatically in interactive TTY sessions and suppressed in non-interactive contexts (`--json`, `--quiet`, `VIPM_NONINTERACTIVE`, CI auto-detect, or when stderr is not a TTY). Pass this flag to force progress over `VIPM_NONINTERACTIVE` / CI / non-TTY (in which case it falls back to periodic single-line updates). It does NOT override `--json` or `--quiet`; those output modes always suppress progress",
       "defaults": [],
       "required": false,
       "multiple": false,
@@ -82,7 +82,7 @@
       "long": "--verbose",
       "short": "v",
       "value_name": "VERBOSE",
-      "description": "Show verbose diagnostic output (API calls, timing, file paths)",
+      "description": "Show additional per-operation detail (e.g. live VIPM Desktop status, per-phase progress)",
       "defaults": [],
       "required": false,
       "multiple": false,
@@ -151,6 +151,22 @@
           "required": false,
           "multiple": false,
           "possible_values": [],
+          "aliases": [],
+          "visible_aliases": [],
+          "conflicts_with": []
+        },
+        {
+          "name": "direct_vipm_io",
+          "long": "--direct-vipm-io",
+          "value_name": "DIRECT_VIPM_IO",
+          "description": "Activate directly with vipm.io (for debugging purposes)",
+          "defaults": [],
+          "required": false,
+          "multiple": false,
+          "possible_values": [
+            "true",
+            "false"
+          ],
           "aliases": [],
           "visible_aliases": [],
           "conflicts_with": []
@@ -1157,7 +1173,7 @@
       "name": "uninstall",
       "description": "Uninstalls one or more packages",
       "access": {
-        "tier": "community",
+        "tier": "free",
         "community_requires_public_repo": true
       },
       "arguments": [
@@ -1681,22 +1697,6 @@
           "conflicts_with": []
         },
         {
-          "name": "no_nipm",
-          "long": "--no-nipm",
-          "value_name": "NO_NIPM",
-          "description": "Skip NIPM feed update",
-          "defaults": [],
-          "required": false,
-          "multiple": false,
-          "possible_values": [
-            "true",
-            "false"
-          ],
-          "aliases": [],
-          "visible_aliases": [],
-          "conflicts_with": []
-        },
-        {
           "name": "force",
           "long": "--force",
           "value_name": "FORCE",
@@ -1711,6 +1711,78 @@
           "aliases": [],
           "visible_aliases": [],
           "conflicts_with": []
+        },
+        {
+          "name": "vipm",
+          "long": "--vipm",
+          "value_name": "VIPM",
+          "description": "Include only VIPM packages",
+          "defaults": [],
+          "required": false,
+          "multiple": false,
+          "possible_values": [
+            "true",
+            "false"
+          ],
+          "aliases": [],
+          "visible_aliases": [],
+          "conflicts_with": [
+            "no_vipm"
+          ]
+        },
+        {
+          "name": "nipm",
+          "long": "--nipm",
+          "value_name": "NIPM",
+          "description": "Include only NIPM packages",
+          "defaults": [],
+          "required": false,
+          "multiple": false,
+          "possible_values": [
+            "true",
+            "false"
+          ],
+          "aliases": [],
+          "visible_aliases": [],
+          "conflicts_with": [
+            "no_nipm"
+          ]
+        },
+        {
+          "name": "no_vipm",
+          "long": "--no-vipm",
+          "value_name": "NO_VIPM",
+          "description": "Exclude VIPM packages from results",
+          "defaults": [],
+          "required": false,
+          "multiple": false,
+          "possible_values": [
+            "true",
+            "false"
+          ],
+          "aliases": [],
+          "visible_aliases": [],
+          "conflicts_with": [
+            "vipm"
+          ]
+        },
+        {
+          "name": "no_nipm",
+          "long": "--no-nipm",
+          "value_name": "NO_NIPM",
+          "description": "Exclude NIPM packages from results",
+          "defaults": [],
+          "required": false,
+          "multiple": false,
+          "possible_values": [
+            "true",
+            "false"
+          ],
+          "aliases": [],
+          "visible_aliases": [],
+          "conflicts_with": [
+            "nipm"
+          ]
         }
       ],
       "subcommands": []

--- a/docs/.snippets/tier-experimental.md
+++ b/docs/.snippets/tier-experimental.md
@@ -1,0 +1,1 @@
+[Experimental](../experimental.md){ .md-button .vipm-tier-pill .vipm-tier-experimental }

--- a/docs/cli/command-reference.md
+++ b/docs/cli/command-reference.md
@@ -13,6 +13,15 @@ These options are available on every command unless noted otherwise. Every comma
 
 --8<-- "_generated/global-options.md"
 
+## Progress Output
+
+Long-running commands display progress on stderr, adapting to where the command runs:
+
+- **Interactive terminals:** progress renders automatically — no flag required.
+- **Non-interactive contexts:** progress is suppressed automatically under `--json`, `--quiet`, `VIPM_NONINTERACTIVE=1`, detected CI environments, or when stderr is piped or redirected.
+- **`--show-progress`:** forces progress on even where it would normally be suppressed. When stderr is not a real terminal, it falls back to periodic single-line `[VIPM] X/Y …` updates. It does not override `--json` or `--quiet`, which always suppress progress.
+- **`--verbose`:** diagnostic output only — it does not produce progress. (Earlier releases emitted periodic `Progress: X/Y downloaded` lines under `--verbose`; that is no longer the case.)
+
 ## Exit Codes
 
 Every command returns exit code `0` on success and a non-zero value on failure. The codes are stable — once assigned, a value never changes meaning, so automation scripts can branch on them safely. A given command emits only the subset relevant to its operation; consult the per-command "Common Issues" notes for command-specific guidance.
@@ -353,12 +362,13 @@ SBOM written to build/bom.json
 
 See [Exit Codes](#exit-codes) for the canonical reference. `vipm sbom` uses codes `0`–`8`, `12`–`15`, `17`, and `18`. Any non-zero exit means the SBOM was **not** produced — the `--output` file is only written on exit code `0`.
 
-On failure, stderr contains a human-readable error message. Example:
+On failure, stderr contains a human-readable error message. When a requested LabVIEW version is not installed, the available versions are listed inline. Example:
 
 ```
-error: No LabVIEW installation found for version '2024'.
-help: Use 'vipm labview-list' to see available versions
+error: 2024 (64-bit). Available versions: 2021 (64-bit), 2024 (32-bit)
 ```
+
+To list installed LabVIEW versions directly, use `vipm labview list` (experimental, Professional Edition).
 
 ### Common Issues
 

--- a/docs/experimental.md
+++ b/docs/experimental.md
@@ -1,0 +1,14 @@
+---
+title: Experimental Features
+description: Experimental features are available for testing and feedback, but are not guaranteed to be supported.
+---
+
+# Experimental Features
+
+Experimental features are available for testing and feedback. They are **not guaranteed to be supported** and may change, become gated to a specific edition, or be removed in a future release without notice.
+
+Use them to evaluate upcoming capabilities and tell us what works — but avoid depending on them in production automation until they graduate to a stable, supported feature.
+
+Anything marked with an Experimental badge — [Experimental](experimental.md){ .md-button .vipm-tier-pill .vipm-tier-experimental } — in this documentation falls under this policy.
+
+--8<-- "need-help.md"

--- a/docs/release-notes/2026.3.md
+++ b/docs/release-notes/2026.3.md
@@ -55,6 +55,8 @@ See the [`vipm search` command reference](../cli/command-reference.md#vipm-searc
 
 Manage NI Package Manager dependencies alongside VIPM packages in a single `vipm.toml` manifest. Declare NIPM feeds, production dependencies, and dev-dependencies in dedicated `[nipm.*]` sections. Add, remove, and lock NIPM packages using the familiar `vipm add --nipm`, `vipm remove --nipm`, and `vipm lock` commands.
 
+- [CLI] `vipm sbom` on `.dragon` files also supports both VIPM and NI Package Manager packages.
+
 See the [NI Packages (NIPM) guide](../vipm-toml/nipm.md) for details.
 
 ## Environment Variables (Applicable to CLI, CI/CD, and Containers)
@@ -111,7 +113,6 @@ Selecting which LabVIEW version VIPM uses is now more flexible and predictable.
 The VIPM CLI now makes package workflows clearer when they need VIPM Desktop or LabVIEW in the background. CLI commands show progress while startup is happening and launch VIPM Desktop and LabVIEW automatically, when needed, which is especially helpful in containers (Docker) and CI/CD environments.
 
 - **[CLI] Visible VIPM Desktop and LabVIEW startup in the console.** CLI commands that use VIPM Desktop, such as `vipm install`, `vipm uninstall`, and `vipm refresh`, show progress while VIPM Desktop opens.
-- **[CLI] Faster VIPM package list refresh.** `vipm refresh` updates the package cache directly before refreshing VIPM Desktop's package list, while showing progress in interactive terminals.
 - **[CLI] More resilient interactive login.** `vipm login` can continue even when the system keyring is unavailable (such as in containerized and CI/CD environments).
 
 ## Discover Installed LabVIEW Versions from the CLI
@@ -120,17 +121,23 @@ Professional Edition users can try the experimental `vipm labview list` command 
 
 - **Preview scope.** `vipm labview list` is marked Experimental and requires Professional Edition while the cross-platform behavior is still being stabilized.
 
+## Refresh the VIPM and NIPM Package Lists/Caches from the CLI
+
+`vipm refresh` is now the single, explicit way to update package information before running another command, with finer control over scope and clearer feedback when something goes wrong.
+
+- **Explicit refresh, not a hidden flag.** `vipm refresh` is the documented way to refresh package indexes before another command; the former global `--refresh` flag has been removed, and stale-index error hints now point to `vipm refresh`.
+- **Scoped, faster refreshes.** Target a single package manager with `--vipm` or `--nipm` to update just the indexes you need.
+- **Up-to-date package lists.** `vipm refresh` updates the CLI package cache before refreshing VIPM Desktop's package list, reducing stale results, and shows progress in interactive terminals.
+- **Actionable, quieter output.** When a package spec fails to download, `vipm refresh` reports an actionable error; full per-spec failure detail appears only with `--verbose`, keeping default output quiet.
+
 ## Additional improvements
 
 - [CLI] LabVIEW project scans run faster on large projects, so `vipm sync` and `vipm sbom` complete more quickly on sizeable `.lvproj` files.
-- [CLI] `vipm search`, `vipm build`, and `vipm sbom` reliably find and use the active `vipm.toml`.
-- [CLI] `vipm sbom` on `.dragon` files supports both VIPM and NI Package Manager packages again.
+- [CLI] `vipm search`, `vipm build`, and `vipm sbom` reliably find and use the active `vipm.toml` up the CWD parent directories.
 - [CLI] Now shows activation expiration in `vipm about`.
-- [CLI] `vipm refresh` is now the explicit way to refresh package indexes before running another command. The former global `--refresh` flag has been removed, and stale-index error hints now point to `vipm refresh`.
 - [CLI] Passing `--vipm` or `--nipm` to a command that doesn't accept them now produces a clear, consistent error.
 - [CLI] A non-VIPM TOML file named `vipm.toml` is now rejected with a clear error rather than partially parsed.
 - [CLI] `vipm.lock` package ordering is now stable across machines and platforms, so `vipm lock` no longer produces spurious diffs.
-- [CLI] `vipm refresh` can now target a specific package manager with `--vipm` or `--nipm` for faster, scoped index updates.
 - [CLI] `vipm install` now displays the correctly resolved LabVIEW version name instead of a raw version identifier.
 - [CLI] `vipm install` failures now surface the underlying error output, making container/headless CI/CD troubleshooting easier.
 

--- a/docs/release-notes/2026.3.md
+++ b/docs/release-notes/2026.3.md
@@ -82,7 +82,7 @@ Updated [Docker](../cli/docker.md) and [GitHub Actions](../cli/github-actions.md
 Long-running operations in the `vipm` command-line interface (CLI) can now be interrupted cleanly with **Ctrl+C** across the CLI, and `vipm sbom` and `vipm sync` additionally support the **`--timeout`** flag — useful when a project scan is taking longer than expected, or to guarantee a CI job cannot hang indefinitely.
 
 - **Ctrl+C handling (CLI).** Pressing Ctrl+C cancels the in-flight CLI operation cleanly rather than leaving the command in an indeterminate state. In addition to `vipm sbom` and `vipm sync`, this now also covers `vipm install`, `vipm cache update`, and `vipm refresh`.
-    - `vipm uninstall` and `vipm build` are also covered (require **VIPM Community** or higher).
+    - `vipm uninstall` and `vipm build` are also covered (`vipm build` requires **VIPM Community** or higher).
 - **`--timeout` flag (CLI).** Sets a maximum wall-clock duration; the CLI command exits with a non-zero code if it exceeds the limit. Works alongside the existing `VIPM_TIMEOUT` environment variable. Applies to `vipm sbom` and `vipm sync`.
 
 ## Stricter Defaults for Project-Scanning CLI Commands
@@ -115,6 +115,17 @@ The VIPM CLI now makes package workflows clearer when they need VIPM Desktop or 
 - **[CLI] Visible VIPM Desktop and LabVIEW startup in the console.** CLI commands that use VIPM Desktop, such as `vipm install`, `vipm uninstall`, and `vipm refresh`, show progress while VIPM Desktop opens.
 - **[CLI] More resilient interactive login.** `vipm login` can continue even when the system keyring is unavailable (such as in containerized and CI/CD environments).
 
+## Automatic Progress Display in Interactive Terminals
+
+Long-running CLI commands such as `vipm install` and `vipm cache update` now show progress **automatically** when run in an interactive terminal — no flag required. This is a behavior change from previous releases, where progress appeared only with `--show-progress`.
+
+- **Auto-on in interactive terminals.** Progress renders automatically for long-running commands; you no longer need `--show-progress` to see it.
+- **Suppressed in non-interactive contexts.** Progress is automatically turned off under `--json`, `--quiet`, `VIPM_NONINTERACTIVE=1`, detected CI environments, or when stderr is piped or redirected, so it never pollutes machine-readable output.
+- **`--show-progress` is now a force-on override.** Use it to force progress even where it would normally be suppressed (CI, `VIPM_NONINTERACTIVE`, non-TTY); in those non-terminal cases it falls back to periodic single-line updates. It does not override `--json` or `--quiet`.
+- **`--verbose` no longer emits progress.** It is diagnostic output only; if you previously used `--verbose` to watch download progress, rely on the automatic display or pass `--show-progress`.
+
+Upgrading: scripts that scrape stderr should set `VIPM_NONINTERACTIVE=1` (if not already) to keep progress off the parsed channel.
+
 ## Discover Installed LabVIEW Versions from the CLI
 
 Professional Edition users can try the experimental `vipm labview list` command on Windows to list LabVIEW installations from the command line. This helps automation and troubleshooting scripts inspect which LabVIEW versions are available without opening VIPM Desktop.
@@ -140,5 +151,6 @@ Professional Edition users can try the experimental `vipm labview list` command 
 - [CLI] `vipm.lock` package ordering is now stable across machines and platforms, so `vipm lock` no longer produces spurious diffs.
 - [CLI] `vipm install` now displays the correctly resolved LabVIEW version name instead of a raw version identifier.
 - [CLI] `vipm install` failures now surface the underlying error output, making container/headless CI/CD troubleshooting easier.
+- [CLI] `vipm uninstall` is now available in Free Edition, matching `vipm install` — previously, removing packages from the command line required a higher edition.
 
 --8<-- "need-help.md"

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -31,6 +31,11 @@
   color: #166534;
 }
 
+.md-typeset .md-button.vipm-tier-experimental {
+  background-color: #ede9fe;
+  color: #5b21b6;
+}
+
 .md-typeset .md-button.vipm-tier-pill:hover,
 .md-typeset .md-button.vipm-tier-pill:focus {
   opacity: 0.85;

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,6 +60,7 @@ markdown_extensions:
 nav:
   - Home: index.md
   - VIPM Editions: vipm-editions-comparison.md
+  - Experimental Features: experimental.md
   - Guides:
     - Software Bill of Materials (SBOM):
       - sbom/index.md

--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -98,11 +98,19 @@ def _run(argv: list[str]) -> None:
 
 
 def _run_zensical_build() -> int | None:
+    # Build with --clean (clear Zensical's cache) every time. Steps 1-2
+    # regenerate the gitignored `_generated/` snippets, but Zensical's
+    # incremental cache keys on each page's own source and does NOT track
+    # `--8<--` snippet includes as dependencies — so a page like
+    # command-reference.md renders from stale cache when only its included
+    # snippet changed. A clean build forces a full re-render. (The fast
+    # incremental path is `just dev`, which does not use this orchestrator.)
+    #
     # Zensical 0.0.x exits 0 even when individual pages hit render errors
     # (e.g., a SnippetMissingError skips the page but the CLI succeeds).
     # Capture output and fail explicitly on any `Error:` line. Replace
     # this wrapper with `zensical build --strict` once upstream ships it.
-    argv = ["zensical", "build"]
+    argv = ["zensical", "build", "--clean"]
     print(f"→ {' '.join(argv)}", file=sys.stderr)
     result = subprocess.run(argv, capture_output=True, text=True)
     sys.stdout.write(result.stdout)

--- a/scripts/generate_cli_snippets.py
+++ b/scripts/generate_cli_snippets.py
@@ -43,7 +43,12 @@ TIER_BADGES_BY_TIER = {
 
 
 def render_tier_badge(access: dict) -> str:
-    badges = TIER_BADGES_BY_TIER.get(access.get("tier"), [])
+    # Experimental is orthogonal to tier (an item can be e.g. professional AND
+    # experimental), so its badge is appended to the same group and rendered
+    # alongside any tier badge.
+    badges = list(TIER_BADGES_BY_TIER.get(access.get("tier"), []))
+    if access.get("experimental"):
+        badges.append("tier-experimental.md")
     if not badges:
         return ""
     return "".join(f'--8<-- "{b}"\n' for b in badges) + "\n"
@@ -68,6 +73,11 @@ def render_usage(cmd: dict) -> str:
 PRO_OPTION_BADGE = (
     "[VIPM Pro](../vipm-editions-comparison.md#available-editions)"
     "{ .md-button .vipm-tier-pill-small .vipm-tier-pro }"
+)
+
+EXPERIMENTAL_OPTION_BADGE = (
+    "[Experimental](../experimental.md)"
+    "{ .md-button .vipm-tier-pill-small .vipm-tier-experimental }"
 )
 
 
@@ -110,6 +120,8 @@ def render_option_row(opt: dict) -> str:
     access = opt.get("access") or {}
     if access.get("tier") == "professional":
         desc = f"{desc} {PRO_OPTION_BADGE}"
+    if access.get("experimental"):
+        desc = f"{desc} {EXPERIMENTAL_OPTION_BADGE}"
 
     return f"| {flag_cell} | {desc} |"
 
@@ -168,6 +180,8 @@ def render_global_option_row(opt: dict) -> str:
     access = opt.get("access") or {}
     if access.get("tier") == "professional":
         desc = f"{desc} {PRO_OPTION_BADGE}"
+    if access.get("experimental"):
+        desc = f"{desc} {EXPERIMENTAL_OPTION_BADGE}"
 
     return f"| {flag_cell} | {desc} |"
 


### PR DESCRIPTION
Keeps the published release notes and the public CLI metadata in step with the latest CLI, so readers see accurate, well-organized information.

## Changes

- **Release notes (2026 Q3 Preview):**
  - Consolidate `vipm refresh` entries into a dedicated functional section so all refresh-related changes live in one place.
  - Note that `vipm refresh` now reports actionable errors when a package spec fails to download, with full per-spec detail under `--verbose`.
- **Public CLI metadata snapshot (`data/vipm-public-cli.json`):** regenerated from the current CLI. Notable surface changes:
  - `uninstall` is now available to the Free tier.
  - `refresh` gains package-manager filters (`--vipm` / `--nipm` / `--no-vipm` / `--no-nipm`).
  - Refined `--show-progress` and `--verbose` help text.

## Test plan

- [ ] `just build` succeeds and the release-notes page renders with the new section
- [ ] The release-notes index table still generates