### PR TITLE
Migrate dev deps to PEP 735 `[dependency-groups]`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,8 @@ dependencies = [
     "zensical>=0.0.33",
 ]
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "pytest>=8",
     "ruff>=0.15.11",
 ]


### PR DESCRIPTION
Silences the `uv` deprecation warning currently printed on every `just check`/`just dev`/`just build` run, and prevents the dev workflow from breaking when `uv` removes the deprecated field in a future release.

## Why

Running any `uv`-backed command currently prints:

```
warning: The `tool.uv.dev-dependencies` field (used in `pyproject.toml`) is deprecated and will be removed in a future release; use `dependency-groups.dev` instead
```

`uv` is moving to the [PEP 735 dependency groups](https://peps.python.org/pep-0735/) standard. Migrating now removes the noise from local builds and keeps CI working when the deprecated field is eventually removed.

## Changes

- Replace `[tool.uv] dev-dependencies` with `[dependency-groups] dev` in `pyproject.toml`.

`uv sync` installs the `dev` group by default, so no developer or CI workflow changes are required.

Closes #113

## Test plan

- [x] `uv sync` installs `pytest` and `ruff` (verified — dev group resolved automatically)
- [x] `just check` runs clean with no deprecation warning (`ruff format --check`, `ruff check`, and 22 pytest tests all pass)