### PR TITLE
Pin GitHub Actions to commit SHAs (and resolve Node.js 20 deprecation)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,9 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
         with:
           enable-cache: true
       - name: Set up Python
@@ -44,7 +44,7 @@ jobs:
       - name: Build and validate docs site
         run: uv run python scripts/build_docs.py
       - name: Upload site artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: site-pr-${{ github.event.pull_request.number || github.run_number }}
           path: site/
@@ -57,11 +57,11 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
         with:
           enable-cache: true
       - name: Set up Python

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -18,11 +18,11 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Install uv
         if: github.event.action != 'closed'
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
         with:
           enable-cache: true
 
@@ -48,6 +48,6 @@ jobs:
         run: uv run python scripts/build_docs.py
 
       - name: Deploy preview
-        uses: rossjrw/pr-preview-action@v1
+        uses: rossjrw/pr-preview-action@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9  # v1.8.1
         with:
           source-dir: ./site/


### PR DESCRIPTION
Closes #115.

GitHub is forcing all actions still running on Node.js 20 to Node.js 24 by default on **2026-06-16**, and will remove Node.js 20 from the runner entirely on **2026-09-16**. Three actions in our workflows currently trigger that deprecation annotation on every CI run. This PR resolves the deprecation by bumping each to a Node.js 24-capable major, and — while every `uses:` line was being touched anyway — adopts SHA pinning across all workflows to harden against retagged-action supply-chain attacks.

## Pinning convention

Going forward, every action in `.github/workflows/` is pinned to its 40-character commit SHA with a trailing version comment:

```yaml
uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
```

The SHA is immutable, so a compromised maintainer cannot retag `v6` to a malicious commit and have our CI pick it up silently. The trailing comment keeps the human-readable version visible during review and works with Dependabot's `version-update` strategy so future bumps update both the SHA and the comment in one diff.

This follows GitHub's [security hardening guide for third-party actions](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) and the OpenSSF Scorecard [pinned-dependencies](https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies) check.

## Versions pinned

| Action | Old | New | SHA |
| --- | --- | --- | --- |
| `actions/checkout` | `v4` | `v6.0.2` | `de0fac2e4500dabe0009e67214ff5f5447ce83dd` |
| `actions/upload-artifact` | `v4` | `v7.0.1` | `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` |
| `astral-sh/setup-uv` | `v6` | `v8.1.0` | `08807647e7069bb48b6ef5acd8ec9567f424441b` |
| `rossjrw/pr-preview-action` | `v1` | `v1.8.1` | `ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9` |

All four SHAs were resolved against `refs/tags/<version>` on each upstream repo at PR-author time.

## Follow-up (deliberately out of scope here)

SHA-pinned actions never get automatic updates unless something is watching for them. A `.github/dependabot.yml` with `package-ecosystem: github-actions` is the standard answer and is worth a separate small PR.

## Test plan

- [ ] `build` job on this PR passes (uses checkout v6, setup-uv v8, upload-artifact v7).
- [ ] `deploy-preview` workflow runs on this PR and posts the preview comment (uses checkout v6, setup-uv v8, pr-preview-action v1.8.1).
- [ ] `deploy` job on the eventual main merge runs cleanly through `mike deploy` (uses checkout v6, setup-uv v8).
- [ ] Deprecation annotation is no longer present in CI run output.