### PR TITLE
Document exit codes a CLI user can hit

### DIFF
--- a/docs/cli/command-reference.md
+++ b/docs/cli/command-reference.md
@@ -31,18 +31,29 @@ Every command returns exit code `0` on success and a non-zero value on failure. 
 | `0` | Success |
 | `1` | Unexpected or unclassified error |
 | `2` | Invalid arguments or failed input validation. Also covers `vipm.lock` being stale or incomplete during dependency-state verification (run `vipm lock`, or pass `--allow-package-drift`). |
+| `3` | Requested package or version does not exist in any repository or manifest |
 | `4` | Requested LabVIEW version is not installed |
+| `5` | Network or repository access failure |
 | `6` | Insufficient edition, license, or activation |
+| `7` | Package dependency conflict |
 | `8` | File system or IO failure |
+| `9` | Package is already installed |
+| `10` | Login or credential failure |
 | `11` | LabVIEW build operation failed (compilation error, App Builder failure, etc.) — `vipm build` only |
 | `12` | Named build target not found in the project |
 | `13` | Input file is not a supported type |
 | `14` | Input file exists but is malformed |
 | `15` | A required file does not exist |
+| `16` | Operation needs user confirmation but cannot prompt (e.g. `--json` mode without `--yes`, or `VIPM_NONINTERACTIVE=1` set). Pass `--yes`/`-y` or `VIPM_ASSUME_YES=1` to auto-confirm. |
 | `17` | Installed packages disagree with the project's declared state in `vipm.toml` or `vipm.lock`. Use `--allow-package-drift` to override. Applies to `vipm build` and `vipm sbom`. |
 | `18` | One or more files referenced by the scanned project could not be found on disk. Use `--allow-missing-files` to override. `vipm sbom` only. |
+| `19` | A detected component (VIPM Desktop, LabVIEW, or NI Package Manager) is from a newer year than this VIPM CLI. Upgrade VIPM CLI to a version whose year matches or exceeds the component's year. |
+| `21` | The requested operation is recognized but not yet implemented in this CLI version. Lets scripts distinguish a feature gap from an unknown argument (code `2`) or a missing package (code `3`). |
+| `22` | Activation failed — the activation service declined the request, the returned code failed local verification, or the VIPM Desktop delegate reported a failure. Distinct from code `10` (login/credential issues). |
+| `124` | Operation timed out before completion (see `--timeout` and the `VIPM_TIMEOUT` environment variable) |
+| `130` | Operation interrupted by the user (Ctrl+C / SIGINT) |
 
-Commands may additionally emit codes not listed here (e.g., authentication, network, or interruption failures). `vipm <command> --help` is the authoritative source for each command. On failure, stderr always contains a human-readable error message.
+`vipm <command> --help` is the authoritative source for which codes a specific command emits. On failure, stderr always contains a human-readable error message.
 
 ## Command Quick Look
 


### PR DESCRIPTION
The canonical exit-codes table in `cli/command-reference.md` previously omitted several codes that the CLI emits in everyday use — package not found (`3`), network/repository failures (`5`), dependency conflicts (`7`), already-installed (`9`), authentication (`10`), confirmation-required (`16`), component-incompatible upper bound (`19`), not-implemented (`21`), activation-failed (`22`), timeout (`124`), and user-interrupted (`130`).

Some of these were vaguely alluded to in the trailing prose ("authentication, network, or interruption failures") but never spelled out, so automation authors had to dig through `vipm <command> --help` to discover them.

Add a row per code with a short user-facing description. Tighten the trailing prose now that the examples it referenced are in the table.

No behavior change; documentation only.

## Test plan
- [x] CI green
- [x] Rendered table at `/cli/command-reference/#exit-codes` includes the new rows