### PR TITLE
Add PowerShell install commands and preview download CTA

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,7 @@
 # VIPM Desktop
 
+[Download VIPM 2026 Q3 Preview](preview.md){ .md-button .md-button--primary .vipm-preview-cta }
+
 ## Downloading VIPM
 
 You can download VIPM from the following locations:

--- a/docs/preview.md
+++ b/docs/preview.md
@@ -12,8 +12,28 @@ VIPM previews give you early access to upcoming features before they're included
 - [Download the Windows installer](https://packages.jki.net/vipm/preview/vipm-setup-latest-preview.exe)
 - Or install via command line:
 
+    **Silent install — PowerShell:**
+
+    ```powershell
+    $ProgressPreference = 'SilentlyContinue'; Invoke-WebRequest -Uri "https://packages.jki.net/vipm/preview/vipm-setup-latest-preview.exe" -OutFile "$env:TEMP\vipm-setup.exe"; Start-Process -Wait -FilePath "$env:TEMP\vipm-setup.exe" -ArgumentList "/exenoui /qn"; Remove-Item "$env:TEMP\vipm-setup.exe" -Force
+    ```
+
+    **Silent install — cmd.exe:**
+
     ```shell
     curl.exe -L https://packages.jki.net/vipm/preview/vipm-setup-latest-preview.exe -o %TEMP%\vipm-setup.exe && start /wait %TEMP%\vipm-setup.exe /quiet /norestart && del %TEMP%\vipm-setup.exe
+    ```
+
+    **Interactive install — PowerShell:**
+
+    ```powershell
+    $ProgressPreference = 'SilentlyContinue'; Invoke-WebRequest -Uri "https://packages.jki.net/vipm/preview/vipm-setup-latest-preview.exe" -OutFile "$env:TEMP\vipm-setup.exe"; Start-Process -Wait -FilePath "$env:TEMP\vipm-setup.exe"; Remove-Item "$env:TEMP\vipm-setup.exe" -Force
+    ```
+
+    **Interactive install — cmd.exe:**
+
+    ```shell
+    curl.exe -L https://packages.jki.net/vipm/preview/vipm-setup-latest-preview.exe -o %TEMP%\vipm-setup.exe && start /wait %TEMP%\vipm-setup.exe && del %TEMP%\vipm-setup.exe
     ```
 
 ### Linux

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -64,6 +64,15 @@
   color: inherit;
 }
 
+/* Preview download CTA — oversized primary button on the home page */
+.md-typeset .md-button.vipm-preview-cta {
+  display: inline-block;
+  font-size: 1.1rem;
+  font-weight: 700;
+  padding: 0.75rem 2rem;
+  margin: 0.5rem 0 1rem;
+}
+
 /* CLI options table — Flag column shrinks to fit its longest content;
    the Description column takes the remaining width. width:1% combined
    with white-space:nowrap is the canonical CSS idiom for this. */


### PR DESCRIPTION
Make it easier for Windows users to install the VIPM preview from the command line and give the preview more visibility on the home page.

## Summary
- Add PowerShell one-liner install commands (silent and interactive) to the preview page alongside the existing cmd.exe commands
- Use `$ProgressPreference = 'SilentlyContinue'` for faster downloads and `$env:TEMP` for clean temp file handling
- Add a prominent "Download VIPM 2026 Q3 Preview" button at the top of the home page linking to `/preview/`

## Test plan
- [x] Verify the home page CTA button renders correctly and links to `/preview/`
- [x] Verify the preview page shows all four command-line install variants (silent/interactive × PowerShell/cmd.exe)
- [x] Test a PowerShell silent install command on a Windows machine