### PR TITLE
Use pinned LabVIEW container image in GitHub Actions examples

### DIFF
--- a/docs/cli/github-actions.md
+++ b/docs/cli/github-actions.md
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     
     container:
-      image: nationalinstruments/labview:latest
+      image: nationalinstruments/labview:2026q1patch2-linux
     
     steps:
       - name: Checkout code
@@ -146,7 +146,7 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
     container:
-      image: nationalinstruments/labview:latest
+      image: nationalinstruments/labview:2026q1patch2-linux
     
     steps:
       - uses: actions/checkout@v4
@@ -198,7 +198,7 @@ jobs:
   build-package:
     runs-on: ubuntu-latest
     container:
-      image: nationalinstruments/labview:latest
+      image: nationalinstruments/labview:2026q1patch2-linux
     
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The GitHub Actions examples used `nationalinstruments/labview:latest` which may resolve to an untested or incompatible image. Pin all three workflow examples to `nationalinstruments/labview:2026q1patch2-linux` so users get a known-working container.

## Summary
- Replace `nationalinstruments/labview:latest` with `nationalinstruments/labview:2026q1patch2-linux` in all three workflow examples (basic, build-and-test, release)

## Test plan
- [x] Verify the three YAML examples in `/cli/github-actions/` render correctly
- [x] Confirm `2026q1patch2-linux` is a valid tag on Docker Hub