### PR TITLE
Document 2026 Q3 spec recovery, opt-in vipm.lock creation, and vipm lock reference

### DIFF
--- a/docs/cli/command-reference.md
+++ b/docs/cli/command-reference.md
@@ -64,11 +64,13 @@ Every command returns exit code `0` on success and a non-zero value on failure. 
 | [`vipm uninstall`](#vipm-uninstall) | Remove packages from the selected LabVIEW installation. |
 | [`vipm list`](#vipm-list) | List installed packages or inspect a `.vipc`/`.dragon` file. |
 | [`vipm info`](#vipm-info) | Show metadata and installed files for a package. |
+| [`vipm search`](#vipm-search) | Search for VIPM and NI packages. |
 | [`vipm refresh`](#vipm-refresh) | Refresh all package sources (VIPM Desktop, CLI cache, NIPM feeds). |
 | [`vipm activate`](#vipm-activate) | Activate VIPM Pro using a serial number, name, and email. |
 | [`vipm build`](#vipm-build) | Build packages from `.vipb` specs or LabVIEW project build specs. |
 | [`vipm sbom`](#vipm-sbom) | Generate a CycloneDX SBOM from a project or manifest. |
 | [`vipm sync`](#vipm-sync) | Reconcile vipm.toml from a LabVIEW project scan. |
+| [`vipm lock`](#vipm-lock) | Generate or check `vipm.lock` from `vipm.toml`. |
 | [`vipm version`](#vipm-version) | Output the CLI and Desktop version numbers. |
 | [`vipm about`](#vipm-about) | Print installation details (paths, versions). |
 
@@ -424,6 +426,12 @@ See [Exit Codes](#exit-codes) for the canonical reference. `vipm sync` uses code
 - **LabVIEW 2024 or newer required for project scans**: applies when scanning a `.lvproj` via `--from`.
 
     --8<-- "labview-interop-link-reference.md"
+
+## `vipm lock`
+
+--8<-- "_generated/commands/lock.md"
+
+Creating `vipm.lock` is opt-in: only `vipm lock` creates the file; `vipm install` refreshes an existing lock without creating one. See the [Lock Files guide](../vipm-toml/getting-started.md#lock-files) for what the lock file records and how to use `vipm lock --check` in CI.
 
 ## `vipm version`
 

--- a/docs/release-notes/2026.3.md
+++ b/docs/release-notes/2026.3.md
@@ -101,6 +101,15 @@ Long-running operations in the `vipm` command-line interface (CLI) can now be in
 - **`vipm install` always preserves dev-dependencies in `vipm.lock`.** Running `vipm install` without `--dev` no longer strips dev-dependencies from the lock file; the lock file remains complete.
 - **`vipm lock --dev` and `--no-dev` flags removed.** Since the lock file always includes dev-dependencies, these flags no longer have an effect and have been removed in this release. Remove them from any scripts that pass them. (`vipm lock` requires **VIPM Community** or higher.)
 
+## `vipm.lock` Creation Is Now Opt-In
+
+Creating a `vipm.lock` file is now an explicit choice: only `vipm lock` creates one. If your workflow depends on a lock file, run `vipm lock` once to create it; subsequent installs keep it up to date. (`vipm lock` requires **VIPM Community** or higher.)
+
+- **`vipm install`** refreshes an existing `vipm.lock`, but no longer creates one in projects that don't have one.
+- **`vipm add` and `vipm remove`** leave `vipm.lock` untouched.
+
+See [`vipm lock`](../cli/command-reference.md#vipm-lock) docs for more information.
+
 ## LabVIEW Version Selection
 
 Selecting which LabVIEW version VIPM uses is now more flexible and predictable.
@@ -167,6 +176,14 @@ VIPM Desktop (2026 Q3 build 3894 or later) detects this condition — at startup
 
 See the [tracking issue](https://github.com/vipm-io/vipm-desktop-issues/issues/130) for full details, including a manual repair procedure you can use with earlier VIPM versions.
 
+## Package Updates Recover When a Repository's Spec File Is Missing
+
+Fixed an issue where a package whose standalone `.spec` (metadata) file is missing from its repository's download server — seen with some packages on the NI LabVIEW Tools Network — caused an error (-124100) during **Check for Package Updates**, and the package could be missing from VIPM's package list entirely, even though it is published and installable.
+
+VIPM now recovers the missing spec from the package file itself: when the spec download reports "not found" but the package file is available, VIPM downloads the package and extracts the embedded spec (the package file contains the same metadata), then ingests it normally. Recovery happens once per package — the recovered spec is cached and reused on later refreshes — and the downloaded package is kept in the cache for install reuse. This applies to both VIPM Desktop's package list updates and the CLI's `vipm refresh`.
+
+See the [tracking issue](https://github.com/vipm-io/vipm-desktop-issues/issues/81) for the original report.
+
 ## Additional improvements
 
 - [CLI] LabVIEW project scans run faster on large projects, so `vipm sync` and `vipm sbom` complete more quickly on sizeable `.lvproj` files.
@@ -178,5 +195,6 @@ See the [tracking issue](https://github.com/vipm-io/vipm-desktop-issues/issues/1
 - [CLI] `vipm install` now displays the correctly resolved LabVIEW version name instead of a raw version identifier.
 - [CLI] `vipm install` failures now surface the underlying error output, making container/headless CI/CD troubleshooting easier.
 - [CLI] `vipm uninstall` is now available in Free Edition, matching `vipm install` — previously, removing packages from the command line required a higher edition.
+- [CLI] `vipm help --json` now publishes a machine-readable catalog of every CLI exit code (number, stable name, and description), so scripts and integrations can interpret exit codes without scraping documentation.
 
 --8<-- "need-help.md"


### PR DESCRIPTION
The 2026 Q3 Preview release notes were missing several user-visible changes shipping in the next Preview build, and the new release-note text needed a `vipm lock` command-reference anchor to link to.

- **Release notes (2026.3):** new section on package updates recovering when a repository's `.spec` file is missing from the download server (tracking issue: vipm-io/vipm-desktop-issues#81); new section on `vipm.lock` creation becoming opt-in; bullet for the machine-readable exit-code catalog in `vipm help --json`.
- **Command reference:** new `vipm lock` entry (generated options snippet plus an opt-in behavior note linking to the Lock Files guide), and missing `vipm lock` / `vipm search` rows added to the Command Quick Look table.

Built locally with `just build` - generate, validate, and post-build checks all green.