### PR TITLE
Note quieter manifest install output and refresh public CLI metadata

### DIFF
--- a/data/vipm-public-cli.json
+++ b/data/vipm-public-cli.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.0-public",
   "cli_version": "dev",
-  "generated_on": "2026-06-08",
+  "generated_on": "2026-06-13",
   "global_options": [
     {
       "name": "labview_version",
@@ -420,7 +420,7 @@
           "name": "lvproj_build_spec",
           "long": "--lvproj-build-spec",
           "value_name": "LVPROJ_BUILD_SPEC",
-          "description": "Name of the build specification within a LabVIEW project file (only for .lvproj files)",
+          "description": "Name of the build specification within a LabVIEW project (.lvproj) file. If omitted, all build specs under the target are built. For vipm.toml build entries of type lvproj, overrides the entry's spec field. Not applicable to .vipb builds",
           "defaults": [],
           "required": false,
           "multiple": false,
@@ -435,7 +435,7 @@
           "name": "lvproj_target",
           "long": "--lvproj-target",
           "value_name": "LVPROJ_TARGET",
-          "description": "Scope build-spec lookup to a specific target within the .lvproj file",
+          "description": "Target within the LabVIEW project (.lvproj) file under which build specs are looked up and built. Defaults to \"My Computer\". For vipm.toml build entries of type lvproj, overrides the entry's target field. Not applicable to .vipb builds",
           "defaults": [],
           "required": false,
           "multiple": false,
@@ -1419,7 +1419,7 @@
           "name": "lvproj_target",
           "long": "--lvproj-target",
           "value_name": "TARGET",
-          "description": "Scope the dependency scan to a specific .lvproj target. May be used alone (scans only that target) or with --lvproj-build-spec (validates the spec is under that target). Omit to scan the whole project",
+          "description": "Scope the dependency scan to a specific .lvproj target. May be used alone (scans only that target) or with --lvproj-build-spec (validates the spec is under that target). Omitting both --lvproj-target and --lvproj-build-spec scans the whole project; omitting only --lvproj-target keeps the scan scoped to the build spec, whose containing target is inferred when the spec name is unique within the LabVIEW project (.lvproj) file",
           "defaults": [],
           "required": false,
           "multiple": false,

--- a/docs/release-notes/2026.3.md
+++ b/docs/release-notes/2026.3.md
@@ -196,5 +196,6 @@ See the [tracking issue](https://github.com/vipm-io/vipm-desktop-issues/issues/8
 - [CLI] `vipm install` failures now surface the underlying error output, making container/headless CI/CD troubleshooting easier.
 - [CLI] `vipm uninstall` is now available in Free Edition, matching `vipm install` — previously, removing packages from the command line required a higher edition.
 - [CLI] `vipm help --json` now publishes a machine-readable catalog of every CLI exit code (number, stable name, and description), so scripts and integrations can interpret exit codes without scraping documentation.
+- [CLI] `vipm install` from a `vipm.toml` with many already-installed dependencies now reports them as a single summary line instead of one notice per package; pass `--verbose` for the full per-package plan.
 
 --8<-- "need-help.md"


### PR DESCRIPTION
Keeps the 2026 Q3 Preview release notes and the generated public CLI reference accurate with the latest CLI behavior, so readers get correct guidance on install output and command help.

- Add an "Additional improvements" note: `vipm install` from a `vipm.toml` with many already-installed dependencies now reports them as a single summary line instead of one notice per package; pass `--verbose` for the full per-package plan.
- Refresh `data/vipm-public-cli.json` with clarified `--lvproj-build-spec` and `--lvproj-target` help text for `vipm build` and project dependency scans.