### PR TITLE
Make just recipes work cross-platform

### DIFF
--- a/justfile
+++ b/justfile
@@ -6,19 +6,14 @@ set shell := ["bash", "-cu"]
 list:
     @just --list
 
-# regenerate generated source snippets (release-notes table)
+# regenerate generated source snippets
 prebuild:
     uv run python scripts/generate_release_notes_table.py
+    uv run python scripts/generate_cli_snippets.py
 
 # build and serve locally (auto-finds open port starting at 8000)
 dev: prebuild
-    #!/usr/bin/env bash
-    port=8000
-    while ss -tlnp | grep -q ":$port "; do
-        port=$((port + 1))
-    done
-    echo "Serving on http://localhost:$port"
-    uv run zensical serve --dev-addr "localhost:$port"
+    uv run python scripts/dev_serve.py
 
 # format Python code with ruff
 format:

--- a/justfile
+++ b/justfile
@@ -1,5 +1,8 @@
 # This file contains useful commands for development tasks.
 
+# run recipe lines in bash on every platform
+set shell := ["bash", "-cu"]
+
 list:
     @just --list
 

--- a/scripts/dev_serve.py
+++ b/scripts/dev_serve.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Serve the docs locally on the first open port at or above 8000.
+
+Backs `just dev`. The port scan lives here, in Python, rather than in a
+shell recipe so it runs identically on Windows, macOS, and Linux. The
+previous shell implementation relied on `ss` (Linux-only) inside a
+`#!/usr/bin/env bash` shebang recipe, which also required `cygpath` on
+Windows — neither is present in a stock Git-for-Windows shell.
+
+Finds an unused TCP port by attempting to bind it, then hands off to
+`zensical serve --dev-addr <host>:<port>`.
+"""
+
+from __future__ import annotations
+
+import socket
+import subprocess
+import sys
+
+DEFAULT_HOST = "localhost"
+DEFAULT_START_PORT = 8000
+
+
+def find_open_port(host: str = DEFAULT_HOST, start: int = DEFAULT_START_PORT) -> int:
+    """Return the first port >= ``start`` on ``host`` that accepts a bind.
+
+    Raises ``OSError`` if no port up to 65535 is free.
+    """
+    for port in range(start, 65536):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            try:
+                sock.bind((host, port))
+            except OSError:
+                continue
+            return port
+    raise OSError(f"no open port available at or above {start} on {host}")
+
+
+def main() -> int:
+    host = DEFAULT_HOST
+    port = find_open_port(host)
+    print(f"Serving on http://{host}:{port}", file=sys.stderr)
+    return subprocess.run(
+        ["zensical", "serve", "--dev-addr", f"{host}:{port}"]
+    ).returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_dev_serve.py
+++ b/tests/test_dev_serve.py
@@ -1,0 +1,54 @@
+"""Tests for the cross-platform dev-server port scan.
+
+Guards `just dev`'s replacement for the old `ss`/bash port loop: it must
+return the start port when free, skip a port that is already bound, and
+fail loudly when nothing is available.
+"""
+
+from __future__ import annotations
+
+import socket
+
+import dev_serve
+
+
+def test_find_open_port_returns_start_when_free():
+    # Bind an ephemeral port, release it, then ask the finder to start
+    # there — it should hand the now-free port straight back.
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+        probe.bind(("localhost", 0))
+        free_port = probe.getsockname()[1]
+
+    assert dev_serve.find_open_port("localhost", free_port) == free_port
+
+
+def test_find_open_port_skips_bound_port():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as held:
+        held.bind(("localhost", 0))
+        taken = held.getsockname()[1]
+
+        result = dev_serve.find_open_port("localhost", taken)
+
+    assert result > taken
+
+
+def test_find_open_port_raises_when_none_free(monkeypatch):
+    # Force every bind to fail so the scan exhausts its range.
+    class _AlwaysBusy:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def bind(self, _addr):
+            raise OSError("busy")
+
+    monkeypatch.setattr(dev_serve.socket, "socket", lambda *a, **k: _AlwaysBusy())
+
+    try:
+        dev_serve.find_open_port("localhost", 65535)
+    except OSError as exc:
+        assert "no open port" in str(exc)
+    else:
+        raise AssertionError("expected OSError when no port is free")


### PR DESCRIPTION
`just dev` failed on Windows: the recipe used a `#!/usr/bin/env bash` shebang with a Linux-only `ss` port scan, so just demanded `cygpath` to translate the interpreter path (absent in a stock Git-for-Windows shell) and then `ss` did not exist either. This makes the justfile run the same way for every contributor regardless of platform.

## Changes

- Pin the recipe shell to bash on every platform: `set shell := ["bash", "-cu"]`.
- Replace the `dev` recipe's bash/`ss` port loop with `scripts/dev_serve.py`, which binds candidate ports to find the first free one at or above 8000 and then hands off to `zensical serve`. No platform-specific shell tooling, and the recipe collapses to a single `uv` call.
- Fix `prebuild` to regenerate the CLI snippets as well — it only ran the release-notes generator, so `dev` served pages that include `_generated/global-options.md` and hit `SnippetMissingError`. (`build` already regenerates both via `build_docs.py`.)
- Add `tests/test_dev_serve.py` covering the port scan (returns a free start port, skips a bound port, raises when none are free).

## Verification

- `just dev` now starts the server cleanly from PowerShell, auto-selecting the next free port when 8000 is taken.
- `just check` passes (ruff format check + lint + 33 tests).