### PR TITLE
Add release note for sbom/sync fresh-machine fix and refresh CLI reference data

### DIFF
--- a/data/vipm-public-cli.json
+++ b/data/vipm-public-cli.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.0-public",
   "cli_version": "dev",
-  "generated_on": "2026-06-13",
+  "generated_on": "2026-06-18",
   "global_options": [
     {
       "name": "labview_version",
@@ -1349,6 +1349,19 @@
           "conflicts_with": []
         },
         {
+          "name": "document_timestamp",
+          "long": "--document-timestamp",
+          "value_name": "ISO8601",
+          "description": "Pin metadata.timestamp to a fixed ISO 8601 instant for reproducible output (overrides the SOURCE_DATE_EPOCH env var; default: generation time). Pair with --document-serial-number for byte-identical SBOMs",
+          "defaults": [],
+          "required": false,
+          "multiple": false,
+          "possible_values": [],
+          "aliases": [],
+          "visible_aliases": [],
+          "conflicts_with": []
+        },
+        {
           "name": "output",
           "long": "--output",
           "value_name": "OUTPUT",
@@ -1392,6 +1405,19 @@
           "long": "--product-type",
           "value_name": "TYPE",
           "description": "Component type of the software described by the SBOM (default: application)",
+          "defaults": [],
+          "required": false,
+          "multiple": false,
+          "possible_values": [],
+          "aliases": [],
+          "visible_aliases": [],
+          "conflicts_with": []
+        },
+        {
+          "name": "product_supplier",
+          "long": "--product-supplier",
+          "value_name": "SUPPLIER",
+          "description": "Software producer / supplier of the software described by the SBOM (CycloneDX `metadata.component.supplier`). Overrides the build-spec company name when both are present",
           "defaults": [],
           "required": false,
           "multiple": false,
@@ -2161,6 +2187,16 @@
       "code": 22,
       "name": "ACTIVATION_FAILED",
       "description": "Activation failed — the service declined the request, the returned code failed verification, or the VIPM Desktop delegate reported a failure"
+    },
+    {
+      "code": 23,
+      "name": "PROJECT_HAS_UNSAVED_CHANGES",
+      "description": "The project is open in a running LabVIEW IDE with unsaved changes, so the on-disk .lvproj is stale"
+    },
+    {
+      "code": 24,
+      "name": "LABVIEW_VI_SERVER_UNAVAILABLE",
+      "description": "LabVIEW VI Server is disabled or not reachable on the resolved target port"
     },
     {
       "code": 124,

--- a/docs/release-notes/2026.3.md
+++ b/docs/release-notes/2026.3.md
@@ -197,5 +197,6 @@ See the [tracking issue](https://github.com/vipm-io/vipm-desktop-issues/issues/8
 - [CLI] `vipm uninstall` is now available in Free Edition, matching `vipm install` — previously, removing packages from the command line required a higher edition.
 - [CLI] `vipm help --json` now publishes a machine-readable catalog of every CLI exit code (number, stable name, and description), so scripts and integrations can interpret exit codes without scraping documentation.
 - [CLI] `vipm install` from a `vipm.toml` with many already-installed dependencies now reports them as a single summary line instead of one notice per package; pass `--verbose` for the full per-package plan.
+- [CLI] `vipm sbom` and `vipm sync` no longer fail on a machine where VIPM Desktop has never run (for example, a CI runner or fresh install): an absent VIPM package database is now treated as "no installed packages", so the scan proceeds with a warning instead of aborting.
 
 --8<-- "need-help.md"


### PR DESCRIPTION
The CLI now generates SBOMs on a fresh machine where VIPM Desktop has never run, so the published release notes and CLI reference data should reflect that and match the current command surface.

- **Release notes (`docs/release-notes/2026.3.md`).** Add an "Additional improvements" bullet: `vipm sbom` and `vipm sync` no longer fail when the VIPM package database is absent (for example, a CI runner or a fresh install). An absent database is treated as "no installed packages", so the scan proceeds and emits a warning instead of aborting.
- **Public CLI reference (`data/vipm-public-cli.json`).** Regenerate the snapshot so it matches the current CLI. This also surfaces the newer `vipm sbom` options `--document-timestamp` and `--product-supplier`, plus exit codes `23` (`PROJECT_HAS_UNSAVED_CHANGES`) and `24` (`LABVIEW_VI_SERVER_UNAVAILABLE`).
