### PR TITLE
Generate the command-reference exit-codes table from CLI metadata

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ Documentation site for [docs.vipm.io](https://docs.vipm.io), built with **Zensic
 - `just check` — No-fix pre-push check: `ruff format --check` + `ruff check` + `pytest`
 - `just test` — Run pytest suite for `scripts/`
 - `just build` — Full pipeline: generate snippets → validate inputs → `zensical build` → validate rendered outputs. Delegates to `scripts/build_docs.py`.
-- `just prebuild` — Regenerate generated snippets only (release-notes table)
+- `just prebuild` — Regenerate generated snippets only (release-notes table and CLI snippets)
 
 Always rebuild after documentation changes and review the output.
 
@@ -22,7 +22,7 @@ Always rebuild after documentation changes and review the output.
 
 - `mkdocs.yml` — Site configuration (Zensical reads mkdocs.yml directly): nav structure, theme, markdown extensions, social links, version provider
 - `docs/` — All documentation content (Markdown files, assets)
-- `docs/.snippets/` — Reusable Markdown snippets included via `pymdownx.snippets` extension. `release-notes-table.md` is generated and gitignored.
+- `docs/.snippets/` — Reusable Markdown snippets included via `pymdownx.snippets` extension. `release-notes-table.md` and `_generated/` CLI snippets are generated and gitignored.
 - `overrides/` — Theme overrides (custom icons in `.icons/custom/`)
 - `scripts/generate_release_notes_table.py` — Prebuild script that reads frontmatter from `docs/release-notes/*.md` and writes the release-notes-table snippet. Runs before every `zensical build` so the rendered site has a fresh table. Replaced the former `hooks.py:on_page_markdown` (Zensical has no native hook API and invokes the build as a subprocess during `mike deploy`, so runtime shims are not an option).
 - `scripts/validate_docs_build.py` — Pre-build validator: checks that generator outputs (e.g., the release-notes snippet) exist and have the expected shape before `zensical build` consumes them.

--- a/dev-docs/cli-docs-improvement-proposal.md
+++ b/dev-docs/cli-docs-improvement-proposal.md
@@ -44,6 +44,7 @@ _Update the tables above each time we complete or add scope so this document sta
 | 2025-11-22 | Clarified CLI index navigation | ✅ | Updated `docs/cli/index.md` Getting Started section to explicitly link to downstream topic pages |
 | 2025-11-22 | Synced CLI pages with command reference availability | ✅ | Updated `docs/cli/index.md`, `docs/cli/getting-started.md`, `docs/cli/docker.md`, and `docs/cli/github-actions.md` to reference the live command reference and current troubleshooting guidance |
 | 2026-05-13 | Replaced `vipm package-list-refresh` examples with `vipm refresh` | ✅ | Modernized tutorial, CI examples, and reference content across `docs/cli/command-reference.md`, `getting-started.md`, `github-actions.md`, `docker.md`, and `index.md` to use the canonical `vipm refresh` command. The command-reference section now uses the generated snippet (`_generated/commands/refresh.md`) from `data/vipm-public-cli.json`, matching the pattern adopted for other commands in #95 |
+| 2026-06-17 | Generated the command-reference exit-code table from public CLI JSON | ✅ | The Exit Codes table now includes the stable `name` field from `data/vipm-public-cli.json` via `_generated/exit-codes.md`, with validation guarding the combined `Exit Code | Meaning` shape. |
 
 ## Decision Register
 

--- a/docs/cli/command-reference.md
+++ b/docs/cli/command-reference.md
@@ -26,33 +26,7 @@ Long-running commands display progress on stderr, adapting to where the command 
 
 Every command returns exit code `0` on success and a non-zero value on failure. The codes are stable — once assigned, a value never changes meaning, so automation scripts can branch on them safely. A given command emits only the subset relevant to its operation; consult the per-command "Common Issues" notes for command-specific guidance.
 
-| Code | Meaning |
-|------|---------|
-| `0` | Success |
-| `1` | Unexpected or unclassified error |
-| `2` | Invalid arguments or failed input validation. Also covers `vipm.lock` being stale or incomplete during dependency-state verification (run `vipm lock`, or pass `--allow-package-drift`). |
-| `3` | Requested package or version does not exist in any repository or manifest |
-| `4` | Requested LabVIEW version is not installed |
-| `5` | Network or repository access failure |
-| `6` | Insufficient edition, license, or activation |
-| `7` | Package dependency conflict |
-| `8` | File system or IO failure |
-| `9` | Package is already installed |
-| `10` | Login or credential failure |
-| `11` | LabVIEW build operation failed (compilation error, App Builder failure, etc.) — `vipm build` only |
-| `12` | Named build target not found in the project |
-| `13` | Input file is not a supported type |
-| `14` | Input file exists but is malformed |
-| `15` | A required file does not exist |
-| `16` | Operation needs user confirmation but cannot prompt (e.g. `--json` mode without `--yes`, or `VIPM_NONINTERACTIVE=1` set). Pass `--yes`/`-y` or `VIPM_ASSUME_YES=1` to auto-confirm. |
-| `17` | Installed packages disagree with the project's declared state in `vipm.toml` or `vipm.lock`. Use `--allow-package-drift` to override. Applies to `vipm build` and `vipm sbom`. |
-| `18` | One or more files referenced by the scanned project could not be found on disk. Use `--allow-missing-files` to override. `vipm sbom` only. |
-| `19` | A detected component (VIPM Desktop, LabVIEW, or NI Package Manager) is from a newer year than this VIPM CLI. Upgrade VIPM CLI to a version whose year matches or exceeds the component's year. |
-| `20` | Resolved LabVIEW target is older than the minimum supported by the command. Install or select LabVIEW 2024 or newer. Applies to `vipm build` (`.lvproj` and `vipm.toml` builds), `vipm sbom` (`.lvproj` input), and `vipm sync` (project scans). |
-| `21` | The requested operation is recognized but not yet implemented in this CLI version. Lets scripts distinguish a feature gap from an unknown argument (code `2`) or a missing package (code `3`). |
-| `22` | Activation failed — the activation service declined the request, the returned code failed local verification, or the VIPM Desktop delegate reported a failure. Distinct from code `10` (login/credential issues). |
-| `124` | Operation timed out before completion (see `--timeout` and the `VIPM_TIMEOUT` environment variable) |
-| `130` | Operation interrupted by the user (Ctrl+C / SIGINT) |
+--8<-- "_generated/exit-codes.md"
 
 `vipm <command> --help` is the authoritative source for which codes a specific command emits. On failure, stderr always contains a human-readable error message.
 

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -81,3 +81,11 @@
   white-space: nowrap;
   width: 1%;
 }
+
+/* CLI exit-code table — the combined code/name cell is a compact identifier;
+   keep it unwrapped and let Meaning take the remaining width. */
+.md-typeset .cli-exit-codes table th:first-child,
+.md-typeset .cli-exit-codes table td:first-child {
+  white-space: nowrap;
+  width: 1%;
+}

--- a/justfile
+++ b/justfile
@@ -3,9 +3,10 @@
 list:
     @just --list
 
-# regenerate generated source snippets (release-notes table)
+# regenerate generated source snippets
 prebuild:
     uv run python scripts/generate_release_notes_table.py
+    uv run python scripts/generate_cli_snippets.py
 
 # build and serve locally (auto-finds open port starting at 8000)
 dev: prebuild

--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -38,6 +38,7 @@ SITE_DIR = REPO_ROOT / "site"
 
 RELEASE_NOTES_INDEX = SITE_DIR / "release-notes" / "index.html"
 REPORT_A_PROBLEM_INDEX = SITE_DIR / "report-a-problem" / "index.html"
+COMMAND_REFERENCE_INDEX = SITE_DIR / "cli" / "command-reference" / "index.html"
 
 
 def _post_release_notes_table_rendered() -> str | None:
@@ -86,9 +87,32 @@ def _post_report_a_problem_redirect() -> str | None:
     return None
 
 
+def _post_cli_exit_code_names_rendered() -> str | None:
+    if not COMMAND_REFERENCE_INDEX.is_file():
+        return (
+            f"missing rendered page: {COMMAND_REFERENCE_INDEX.relative_to(REPO_ROOT)}"
+        )
+    html = COMMAND_REFERENCE_INDEX.read_text()
+    markers = [
+        "<th>Exit Code</th>",
+        "<code>SUCCESS</code>",
+        "<code>USER_INTERRUPTED</code>",
+    ]
+    missing = [marker for marker in markers if marker not in html]
+    if missing:
+        return (
+            f"{COMMAND_REFERENCE_INDEX.relative_to(REPO_ROOT)} is missing rendered "
+            f"CLI exit-code name marker(s): {', '.join(missing)}. Check the "
+            f"`_generated/exit-codes.md` snippet include in "
+            f"docs/cli/command-reference.md."
+        )
+    return None
+
+
 POST_BUILD_CHECKS = [
     _post_release_notes_table_rendered,
     _post_report_a_problem_redirect,
+    _post_cli_exit_code_names_rendered,
 ]
 
 

--- a/scripts/generate_cli_snippets.py
+++ b/scripts/generate_cli_snippets.py
@@ -24,7 +24,9 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SOURCE = REPO_ROOT / "data" / "vipm-public-cli.json"
-OUTDIR = REPO_ROOT / "docs" / ".snippets" / "_generated" / "commands"
+GENERATED_DIR = REPO_ROOT / "docs" / ".snippets" / "_generated"
+OUTDIR = GENERATED_DIR / "commands"
+EXIT_CODES_SNIPPET = GENERATED_DIR / "exit-codes.md"
 
 # Per-tier badge inclusion. "Free" and "always_allowed" mean "available
 # in all editions" — readers can infer that from the absence of a badge,
@@ -205,6 +207,27 @@ def render_global_options_snippet(global_options: list) -> str:
     return "\n".join(lines) + "\n"
 
 
+def render_exit_code_row(exit_code: dict) -> str:
+    code = exit_code["code"]
+    name = exit_code["name"]
+    desc = exit_code["description"].replace("|", "\\|").replace("\n", " ")
+    return f"| `{code}` `{name}` | {desc} |"
+
+
+def render_exit_codes_snippet(exit_codes: list) -> str:
+    rows = [render_exit_code_row(exit_code) for exit_code in exit_codes]
+    lines = [
+        '<div class="cli-options cli-exit-codes" markdown>',
+        "",
+        "| Exit Code | Meaning |",
+        "|---|---|",
+        *rows,
+        "",
+        "</div>",
+    ]
+    return "\n".join(lines) + "\n"
+
+
 def main() -> None:
     if not SOURCE.is_file():
         sys.exit(f"missing source: {SOURCE}")
@@ -221,10 +244,12 @@ def main() -> None:
     global_snippet_path.write_text(
         render_global_options_snippet(data.get("global_options", []))
     )
+    EXIT_CODES_SNIPPET.write_text(render_exit_codes_snippet(data.get("exit_codes", [])))
 
     print(
         f"wrote {written} command snippet(s) to {OUTDIR.relative_to(REPO_ROOT)}, "
-        f"plus {global_snippet_path.relative_to(REPO_ROOT)}"
+        f"plus {global_snippet_path.relative_to(REPO_ROOT)} and "
+        f"{EXIT_CODES_SNIPPET.relative_to(REPO_ROOT)}"
     )
 
 

--- a/scripts/validate_docs_build.py
+++ b/scripts/validate_docs_build.py
@@ -8,9 +8,10 @@ generator's internal checks don't surface:
   1. Generated snippet files exist where `pymdownx.snippets` expects
      them (stronger than `check_paths: true`'s file-exists test, since
      we also verify content shape).
-  2. Each generated snippet has the expected shape — for the release-
-     notes table, at least one data row. Catches output-format drift
-     if the generator is refactored.
+  2. Each generated snippet has the expected shape - for the release-
+     notes table, at least one data row; for the CLI exit-codes table,
+     named exit-code rows. Catches output-format drift if a generator
+     is refactored.
 
 All checks run; every failure is reported in one CI log so authors see
 the full picture. Extend ``CHECKS`` when new prebuild artifacts land.
@@ -26,6 +27,9 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 
 RELEASE_NOTES_TABLE = REPO_ROOT / "docs" / ".snippets" / "release-notes-table.md"
 RELEASE_NOTES_ROW_RE = re.compile(r"^\| <a href", re.MULTILINE)
+EXIT_CODES_TABLE = REPO_ROOT / "docs" / ".snippets" / "_generated" / "exit-codes.md"
+EXIT_CODES_HEADER_RE = re.compile(r"^\| Exit Code \| Meaning \|$", re.MULTILINE)
+EXIT_CODE_NAME_ROW_RE = re.compile(r"^\| `\d+` `[A-Z0-9_]+` \|", re.MULTILINE)
 
 
 def _check_release_notes_table() -> str | None:
@@ -45,7 +49,25 @@ def _check_release_notes_table() -> str | None:
     return None
 
 
-CHECKS = [_check_release_notes_table]
+def _check_exit_codes_table() -> str | None:
+    rel = EXIT_CODES_TABLE.relative_to(REPO_ROOT)
+    if not EXIT_CODES_TABLE.is_file():
+        return (
+            f"missing: {rel} - run `scripts/generate_cli_snippets.py` "
+            f"(or `just prebuild`) before building."
+        )
+    content = EXIT_CODES_TABLE.read_text()
+    if not EXIT_CODES_HEADER_RE.search(content):
+        return f"malformed: {rel} is missing the `Exit Code | Meaning` header."
+    if not EXIT_CODE_NAME_ROW_RE.search(content):
+        return (
+            f"empty: {rel} has no named exit-code rows. The CLI JSON may be "
+            f"missing `exit_codes[].name`, or the output format has drifted."
+        )
+    return None
+
+
+CHECKS = [_check_release_notes_table, _check_exit_codes_table]
 
 
 def main() -> int:

--- a/tests/test_build_docs_validators.py
+++ b/tests/test_build_docs_validators.py
@@ -53,6 +53,50 @@ def test_pre_build_snippet_with_rows_ok(tmp_path, monkeypatch):
     assert validate_docs_build._check_release_notes_table() is None
 
 
+# --- validate_docs_build._check_exit_codes_table ------------------------
+
+
+def test_pre_build_missing_exit_codes_table(tmp_path, monkeypatch):
+    snippet = tmp_path / "missing" / "exit-codes.md"
+    monkeypatch.setattr(validate_docs_build, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(validate_docs_build, "EXIT_CODES_TABLE", snippet)
+
+    result = validate_docs_build._check_exit_codes_table()
+
+    assert result is not None
+    assert "missing:" in result
+    assert "exit-codes.md" in result
+
+
+def test_pre_build_exit_codes_table_without_combined_column_fails(
+    tmp_path, monkeypatch
+):
+    snippet = tmp_path / "exit-codes.md"
+    snippet.write_text(
+        "| Code | Name | Meaning |\n|---|---|---|\n| `0` | `SUCCESS` | Success |\n"
+    )
+    monkeypatch.setattr(validate_docs_build, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(validate_docs_build, "EXIT_CODES_TABLE", snippet)
+
+    result = validate_docs_build._check_exit_codes_table()
+
+    assert result is not None
+    assert "Exit Code | Meaning" in result
+
+
+def test_pre_build_exit_codes_table_with_named_rows_ok(tmp_path, monkeypatch):
+    snippet = tmp_path / "exit-codes.md"
+    snippet.write_text(
+        "| Exit Code | Meaning |\n"
+        "|---|---|\n"
+        "| `0` `SUCCESS` | Operation completed successfully |\n"
+    )
+    monkeypatch.setattr(validate_docs_build, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(validate_docs_build, "EXIT_CODES_TABLE", snippet)
+
+    assert validate_docs_build._check_exit_codes_table() is None
+
+
 # --- build_docs._post_release_notes_table_rendered ----------------------
 
 
@@ -162,3 +206,50 @@ def test_post_report_a_problem_missing_refresh_fails(tmp_path, monkeypatch):
     result = build_docs._post_report_a_problem_redirect()
 
     assert result is not None
+
+
+# --- build_docs._post_cli_exit_code_names_rendered ----------------------
+
+
+def _point_command_reference_at(monkeypatch, tmp_path: Path, html_path: Path) -> None:
+    monkeypatch.setattr(build_docs, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(build_docs, "COMMAND_REFERENCE_INDEX", html_path)
+
+
+def test_post_cli_exit_code_names_missing_file(tmp_path, monkeypatch):
+    html_path = tmp_path / "site" / "cli" / "command-reference" / "index.html"
+    _point_command_reference_at(monkeypatch, tmp_path, html_path)
+
+    result = build_docs._post_cli_exit_code_names_rendered()
+
+    assert result is not None
+    assert "missing rendered page" in result
+
+
+def test_post_cli_exit_code_names_without_exit_code_column_fails(tmp_path, monkeypatch):
+    html_path = tmp_path / "site" / "cli" / "command-reference" / "index.html"
+    _write_html(
+        html_path,
+        "<table><tr><th>Code</th><th>Name</th><th>Meaning</th></tr>"
+        "<tr><td><code>0</code></td><td>Success</td></tr></table>",
+    )
+    _point_command_reference_at(monkeypatch, tmp_path, html_path)
+
+    result = build_docs._post_cli_exit_code_names_rendered()
+
+    assert result is not None
+    assert "<th>Exit Code</th>" in result
+
+
+def test_post_cli_exit_code_names_rendered_ok(tmp_path, monkeypatch):
+    html_path = tmp_path / "site" / "cli" / "command-reference" / "index.html"
+    _write_html(
+        html_path,
+        "<table><tr><th>Exit Code</th><th>Meaning</th></tr>"
+        "<tr><td><code>0</code> <code>SUCCESS</code></td><td>Success</td></tr>"
+        "<tr><td><code>130</code> <code>USER_INTERRUPTED</code></td>"
+        "<td>Interrupted</td></tr></table>",
+    )
+    _point_command_reference_at(monkeypatch, tmp_path, html_path)
+
+    assert build_docs._post_cli_exit_code_names_rendered() is None

--- a/tests/test_generate_cli_snippets.py
+++ b/tests/test_generate_cli_snippets.py
@@ -1,0 +1,30 @@
+"""Tests for generated CLI markdown snippets."""
+
+from __future__ import annotations
+
+import generate_cli_snippets
+
+
+def test_render_exit_codes_snippet_includes_name_column() -> None:
+    snippet = generate_cli_snippets.render_exit_codes_snippet(
+        [
+            {
+                "code": 0,
+                "name": "SUCCESS",
+                "description": "Operation completed successfully",
+            },
+            {
+                "code": 2,
+                "name": "COMMAND_SYNTAX_ERROR",
+                "description": "Invalid arguments | failed input validation\nretry",
+            },
+        ]
+    )
+
+    assert '<div class="cli-options cli-exit-codes" markdown>' in snippet
+    assert "| Exit Code | Meaning |" in snippet
+    assert "| `0` `SUCCESS` | Operation completed successfully |" in snippet
+    assert (
+        "| `2` `COMMAND_SYNTAX_ERROR` | Invalid arguments \\| "
+        "failed input validation retry |"
+    ) in snippet


### PR DESCRIPTION
The CLI command reference carried a hand-maintained exit-codes table that could drift from the CLI's real codes and didn't surface the stable code names automation should branch on. This generates that table from the published CLI metadata instead, so it stays in sync and shows each code's stable name.

- Replace the hand-written Exit Codes table in `docs/cli/command-reference.md` with a generated snippet (`--8<-- "_generated/exit-codes.md"`).
- Add `scripts/generate_cli_snippets.py` to render the exit-codes snippet from `data/vipm-public-cli.json` (code, stable name, meaning); wire it into `just prebuild` / `just build`.
- Add a `validate_docs_build.py` check guarding the generated table's shape, with unit tests for the generator and validator.
- Update `CLAUDE.md` and the CLI-docs improvement log.

Depends on #130 for complete data: the generated table draws its code list from `data/vipm-public-cli.json`, and #130 refreshes that metadata to include exit codes 23 and 24. Merge #130 first (or together) so the rendered table is complete.
