### PR TITLE
Point home download button at the live download page for GA

### DIFF
--- a/docs/cli/docker.md
+++ b/docs/cli/docker.md
@@ -145,7 +145,7 @@ Building VI Package from path/to/your_package.vipb
 ✓ Build completed: builds/your_package.vip
 ```
 
-**Note**: Package building on Linux is currently under development and may have some limitations. Check the [VIPM 2026 Q3](https://docs.vipm.io/preview/) for the latest updates.
+**Note**: Package building on Linux is currently under development and may have some limitations. Check the [VIPM 2026 Q3 release notes](../release-notes/2026.3.md) for the latest updates.
 
 ## Use Cases for Containers
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # VIPM Desktop
 
-[Download VIPM 2026 Q3](preview.md){ .md-button .md-button--primary .vipm-preview-cta }
+[Download VIPM 2026 Q3](https://vipm.io/desktop){ .md-button .md-button--primary .vipm-preview-cta }
 
 ## Downloading VIPM
 


### PR DESCRIPTION
Now that 2026 Q3 is GA and `latest`, the home-page download button and a Docker-guide cross-link still pointed into the `/preview/` early-access page, leaving the primary "Download VIPM 2026 Q3" call-to-action broken (it resolved to `/latest/preview/`).

## Changes

- Point the home-page **Download VIPM 2026 Q3** button at the canonical download page, `https://vipm.io/desktop` (the same "Current Releases" link the page lists below the button).
- Re-point a Docker-guide "VIPM 2026 Q3" note from `https://docs.vipm.io/preview/` to the versioned `2026.3` release notes (relative link, stays correct per docs version).

## Out of scope (flagged separately)

- `docs/cli/github-actions.md` installs from `packages.jki.net/vipm/preview/vipm_latest_preview_amd64.deb` (the preview package channel). That's a functional CI install URL, not a docs link — needs the correct GA package-channel path before changing.

## Test

- `just build` passes (generate → validate-pre → build → validate-post).
