### PR TITLE
De-emphasize docs version selector; move version discovery to footer

### DIFF
--- a/docs/versions.md
+++ b/docs/versions.md
@@ -1,0 +1,12 @@
+---
+title: Documentation Versions
+description: Find the VIPM documentation that matches your installed version, including past releases and the in-development preview.
+---
+
+# Documentation Versions
+
+This documentation is published in versioned snapshots, so you can read the docs that match the VIPM you have installed. The latest stable release is shown by default at [docs.vipm.io](https://docs.vipm.io/).
+
+- **[2026 Q3 (latest)](https://docs.vipm.io/latest/)** — the current stable release.
+- [2026 Q1](https://docs.vipm.io/2026-Q1/) — the previous stable release.
+- [Preview](https://docs.vipm.io/preview/) — in-development docs for the next release; content may change before it ships.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,7 @@ site_url: https://docs.vipm.io
 repo_name: vipm-io/docs
 edit_uri: edit/main/docs/
 repo_url: https://github.com/vipm-io/docs
-copyright: Copyright &copy; 2026 VIPM Community Contributors
+copyright: 'Copyright &copy; 2026 VIPM Community Contributors &nbsp;&middot;&nbsp; <a href="https://docs.vipm.io/latest/versions/">Documentation versions</a>'
 
 theme:
   name: material
@@ -29,9 +29,6 @@ theme:
 
 extra:
   homepage: https://vipm.io
-  version:
-    provider: mike
-    default: latest
   social:
     - icon: custom/vipm
       link: https://vipm.io


### PR DESCRIPTION
The navbar version selector listed `preview` as the first option with no clear "latest" label, so visitors could switch to in-development docs by mistake and not realize 2026 Q3 is the current release.

## Changes

- **Remove the prominent header version dropdown** by dropping `extra.version` (provider/default). The Material/Zensical switcher is rendered from this; without it, the header no longer shows the version menu. (The mike-native `version_selector: false` flag does not suppress the switcher in the current Zensical + mike-fork integration, so this is the reliable lever.)
- **Add a quiet "Documentation versions" link in the footer** (next to the copyright) pointing to a new `docs/versions.md` page that lists 2026 Q3 (latest), 2026 Q1, and the preview channel with short descriptions.

## Unaffected

- All versioned URLs still resolve (`/latest/`, `/2026-Q1/`, `/preview/`); the root still redirects to latest. mike deploys are unchanged.

## Tradeoffs (intentional)

- No Material outdated-version banner (it shares the same `extra.version` gate). 
- `versions.md` is hand-maintained — add a line per release.

## Test

- `just build` passes; rendered `__config.version` is `null` (no switcher), footer link renders, `/versions/` page builds.
