### PR TITLE
Drop 'Linux and' from the 2022 beta download label

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ You can download VIPM from the following locations:
 
 - Current Releases: [vipm.io/desktop](https://vipm.io/desktop)
 - Past Releases: [vipm.io/desktop/versions/](https://www.vipm.io/desktop/versions/)
-- [VIPM 2022 beta for Linux and Mac](https://forums.vipm.io/topic/6423-announcing-the-vipm-2022-for-mac-and-linux-public-beta/)
+- [VIPM 2022 beta for Mac](https://forums.vipm.io/topic/6423-announcing-the-vipm-2022-for-mac-and-linux-public-beta/)
 
 ## Compare Editions
 - [Compare VIPM editions](vipm-editions-comparison.md) to find the version that matches your development needs.


### PR DESCRIPTION
Linux is now a GA platform served from the main download page, so the legacy 2022 public beta is only relevant for Mac. Relabel the home-page download link text to "VIPM 2022 beta for Mac" (the Mac download location is a separate follow-up).

## Test
- `just build` passes; the link renders as "VIPM 2022 beta for Mac".