### PR TITLE
Fix malformed front matter leaking 'title:' text on docs pages

### DIFF
--- a/docs/cli/command-reference.md
+++ b/docs/cli/command-reference.md
@@ -1,4 +1,6 @@
+---
 title: Command Reference
+---
 
 # VIPM CLI Command Reference
 

--- a/docs/cli/docker.md
+++ b/docs/cli/docker.md
@@ -1,4 +1,6 @@
+---
 title: Docker Containers
+---
 
 # Using VIPM in Docker Containers
 

--- a/docs/cli/getting-started.md
+++ b/docs/cli/getting-started.md
@@ -1,4 +1,6 @@
+---
 title: Getting Started
+---
 
 # Getting Started with the VIPM CLI
 

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -1,4 +1,6 @@
+---
 title: Overview
+---
 
 # Using VIPM via Command-Line Interface (CLI)
 

--- a/docs/linux/index.md
+++ b/docs/linux/index.md
@@ -1,4 +1,6 @@
+---
 title: Overview
+---
 
 # VIPM on Linux
 

--- a/docs/publishing-packages/index.md
+++ b/docs/publishing-packages/index.md
@@ -1,4 +1,6 @@
+---
 title: Overview
+---
 
 # Publishing Packages
 


### PR DESCRIPTION
Six pages began with a bare `title:` line and **no `---` fences**, so the front matter wasn't parsed and rendered as literal "title: …" text above the page H1 (visible on `/linux/`, `/cli/`, `/cli/getting-started/`, `/cli/command-reference/`, `/cli/docker/`, `/publishing-packages/`).

## Fix
Wrap each page's `title:` in proper `---` front-matter fences. This also makes the intended short titles take effect (nav/`<title>`).

## Test
- `just build` passes; rendered site has zero leaked `title:` strings.