### PR TITLE
Add persistent 'Download VIPM' call-to-action to the docs header

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -89,3 +89,39 @@
   white-space: nowrap;
   width: 1%;
 }
+
+/* Persistent "Download VIPM" call-to-action in the header (every page) */
+.md-header__button.md-download-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin: 0 0.4rem;
+  padding: 0.35rem 0.7rem;
+  border-radius: 0.2rem;
+  background-color: #ff5800;
+  color: #fff;
+  font-size: 0.72rem;
+  font-weight: 700;
+  white-space: nowrap;
+  opacity: 1;
+}
+.md-header__button.md-download-cta:hover,
+.md-header__button.md-download-cta:focus {
+  background-color: #e64f00;
+  color: #fff;
+  opacity: 1;
+}
+.md-header__button.md-download-cta svg {
+  width: 1rem;
+  height: 1rem;
+  fill: currentColor;
+}
+/* On narrow screens, show just the download icon to save space */
+@media screen and (max-width: 76.1875em) {
+  .md-download-cta__label {
+    display: none;
+  }
+  .md-header__button.md-download-cta {
+    padding: 0.35rem;
+  }
+}

--- a/overrides/partials/header.html
+++ b/overrides/partials/header.html
@@ -1,0 +1,75 @@
+{#-
+  Customized copy of Zensical's partials/header.html.
+  Adds a persistent "Download VIPM" call-to-action to the header.
+  Re-sync with the upstream partial when bumping Zensical.
+-#}
+{% set class = "md-header" %}
+{% if "navigation.tabs.sticky" in features %}
+  {% set class = class ~ " md-header--shadow md-header--lifted" %}
+{% elif "navigation.tabs" not in features %}
+  {% set class = class ~ " md-header--shadow" %}
+{% endif %}
+<header class="{{ class }}" data-md-component="header">
+  <nav class="md-header__inner md-grid" aria-label="{{ lang.t('header') }}">
+    <a href="{{ config.extra.homepage | d(nav.homepage.url, true) | url }}" title="{{ config.site_name | e }}" class="md-header__button md-logo" aria-label="{{ config.site_name }}" data-md-component="logo">
+      {% include "partials/logo.html" %}
+    </a>
+    <label class="md-header__button md-icon" for="__drawer" aria-label="{{ lang.t('nav') }}">
+      {% set icon = config.theme.icon.menu or "material/menu" %}
+      {% include ".icons/" ~ icon ~ ".svg" %}
+    </label>
+    <div class="md-header__title" data-md-component="header-title">
+      <div class="md-header__ellipsis">
+        <div class="md-header__topic">
+          <span class="md-ellipsis">
+            {{ config.site_name }}
+          </span>
+        </div>
+        <div class="md-header__topic" data-md-component="header-topic">
+          <span class="md-ellipsis">
+            {% if page.meta and page.meta.title %}
+              {{ page.meta.title }}
+            {% else %}
+              {{ page.title }}
+            {% endif %}
+          </span>
+        </div>
+      </div>
+    </div>
+    {% if config.theme.palette %}
+      {% if not config.theme.palette is mapping %}
+        {% include "partials/palette.html" %}
+      {% endif %}
+    {% endif %}
+    {% if not config.theme.palette is mapping %}
+      {% include "partials/javascripts/palette.html" %}
+    {% endif %}
+    {% if config.extra.alternate %}
+      {% include "partials/alternate.html" %}
+    {% endif %}
+    {% if "search" in config.plugins %}
+      {% set search = config.plugins["search"] | attr("config") %}
+      {% if search.enabled %}
+        <label class="md-header__button md-icon" for="__search" aria-label="{{ lang.t('search') }}">
+          {% set icon = config.theme.icon.search or "material/magnify" %}
+          {% include ".icons/" ~ icon ~ ".svg" %}
+        </label>
+        {% include "partials/search.html" %}
+      {% endif %}
+    {% endif %}
+    <a href="https://www.vipm.io/download/" class="md-header__button md-download-cta" title="Download VIPM">
+      {% include ".icons/material/download.svg" %}
+      <span class="md-download-cta__label">Download VIPM</span>
+    </a>
+    <div class="md-header__source">
+      {% if config.repo_url %}
+        {% include "partials/source.html" %}
+      {% endif %}
+    </div>
+  </nav>
+  {% if "navigation.tabs.sticky" in features %}
+    {% if "navigation.tabs" in features %}
+      {% include "partials/tabs.html" %}
+    {% endif %}
+  {% endif %}
+</header>


### PR DESCRIPTION
People who land on **any** docs page should have an obvious way to get VIPM, mirroring the "Get VIPM" item on the vipm.io navbar.

## Changes

- Override `partials/header.html` (a copy of Zensical's header) to add a persistent **Download VIPM** button to the header, visible on every page. It links to `https://www.vipm.io/download/`.
- Style it as a prominent orange pill with a download icon in `stylesheets/extra.css`; on narrow screens it collapses to just the icon.

## Notes

- The header override is a copy of Zensical's auto-generated header partial — re-sync it whenever Zensical is bumped.
- Link target is `vipm.io/download` to match the vipm.io "Get VIPM" behavior; easy to repoint to the docs *Installing VIPM* page if preferred.

## Preview / test

- Use the PR preview to view the button in the header. `just build` passes.
