### PR TITLE
Remove redundant home-page Download button

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,5 @@
 # VIPM Desktop
 
-[Download VIPM 2026 Q3](https://vipm.io/desktop){ .md-button .md-button--primary .vipm-preview-cta }
-
 ## Downloading VIPM
 
 You can download VIPM from the following locations:

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -64,15 +64,6 @@
   color: inherit;
 }
 
-/* Preview download CTA — oversized primary button on the home page */
-.md-typeset .md-button.vipm-preview-cta {
-  display: inline-block;
-  font-size: 1.1rem;
-  font-weight: 700;
-  padding: 0.75rem 2rem;
-  margin: 0.5rem 0 1rem;
-}
-
 /* CLI options table — Flag column shrinks to fit its longest content;
    the Description column takes the remaining width. width:1% combined
    with white-space:nowrap is the canonical CSS idiom for this. */


### PR DESCRIPTION
The header now has a persistent **Download VIPM** call-to-action on every page, so the large "Download VIPM 2026 Q3" button under the home-page heading is redundant.

## Changes
- Remove the home-page download button from `index.md`.
- Remove its now-unused `.vipm-preview-cta` CSS rule.

## Test
- `just build` passes; the header Download button is unaffected.