### PR TITLE
Add copy buttons to install commands

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -18,25 +18,25 @@ Download VIPM from **[vipm.io/download](https://www.vipm.io/download/)** and run
 
 **Silent install — PowerShell:**
 
-```powershell
+``` { .powershell .copy }
 $ProgressPreference = 'SilentlyContinue'; Invoke-WebRequest -Uri "https://traffic.libsyn.com/secure/jkinc/vipm-26.3.3954-windows-setup.exe" -OutFile "$env:TEMP\vipm-setup.exe"; Start-Process -Wait -FilePath "$env:TEMP\vipm-setup.exe" -ArgumentList "/exenoui /qn"; Remove-Item "$env:TEMP\vipm-setup.exe" -Force
 ```
 
 **Silent install — cmd.exe:**
 
-```shell
+``` { .shell .copy }
 curl.exe -L https://traffic.libsyn.com/secure/jkinc/vipm-26.3.3954-windows-setup.exe -o %TEMP%\vipm-setup.exe && start /wait %TEMP%\vipm-setup.exe /quiet /norestart && del %TEMP%\vipm-setup.exe
 ```
 
 **Interactive install — PowerShell:**
 
-```powershell
+``` { .powershell .copy }
 $ProgressPreference = 'SilentlyContinue'; Invoke-WebRequest -Uri "https://traffic.libsyn.com/secure/jkinc/vipm-26.3.3954-windows-setup.exe" -OutFile "$env:TEMP\vipm-setup.exe"; Start-Process -Wait -FilePath "$env:TEMP\vipm-setup.exe"; Remove-Item "$env:TEMP\vipm-setup.exe" -Force
 ```
 
 **Interactive install — cmd.exe:**
 
-```shell
+``` { .shell .copy }
 curl.exe -L https://traffic.libsyn.com/secure/jkinc/vipm-26.3.3954-windows-setup.exe -o %TEMP%\vipm-setup.exe && start /wait %TEMP%\vipm-setup.exe && del %TEMP%\vipm-setup.exe
 ```
 
@@ -44,15 +44,29 @@ curl.exe -L https://traffic.libsyn.com/secure/jkinc/vipm-26.3.3954-windows-setup
 
 **Debian-based (Ubuntu, Debian, Linux Mint, and derivatives):**
 
-```shell
+``` { .shell .copy }
 wget -O /tmp/vipm.deb https://traffic.libsyn.com/secure/jkinc/vipm_26.3.0-3954_amd64.deb && sudo dpkg -i /tmp/vipm.deb && rm /tmp/vipm.deb
 ```
 
 **Red Hat-based (RHEL, Fedora, CentOS, Rocky Linux, and derivatives):**
 
-- **dnf (RHEL 8+ / Fedora / Rocky Linux / AlmaLinux):** `wget -O /tmp/vipm.rpm https://traffic.libsyn.com/secure/jkinc/vipm-26.3.0-3954.x86_64.rpm && sudo dnf install -y --nogpgcheck /tmp/vipm.rpm && rm /tmp/vipm.rpm`
-- **yum (RHEL 7 / CentOS 7):** `wget -O /tmp/vipm.rpm https://traffic.libsyn.com/secure/jkinc/vipm-26.3.0-3954.x86_64.rpm && sudo yum install -y --nogpgcheck /tmp/vipm.rpm && rm /tmp/vipm.rpm`
-- **zypper (openSUSE):** `wget -O /tmp/vipm.rpm https://traffic.libsyn.com/secure/jkinc/vipm-26.3.0-3954.x86_64.rpm && sudo zypper --non-interactive install --no-recommends --allow-unsigned-rpm /tmp/vipm.rpm && rm /tmp/vipm.rpm`
+**dnf (RHEL 8+ / Fedora / Rocky Linux / AlmaLinux):**
+
+``` { .shell .copy }
+wget -O /tmp/vipm.rpm https://traffic.libsyn.com/secure/jkinc/vipm-26.3.0-3954.x86_64.rpm && sudo dnf install -y --nogpgcheck /tmp/vipm.rpm && rm /tmp/vipm.rpm
+```
+
+**yum (RHEL 7 / CentOS 7):**
+
+``` { .shell .copy }
+wget -O /tmp/vipm.rpm https://traffic.libsyn.com/secure/jkinc/vipm-26.3.0-3954.x86_64.rpm && sudo yum install -y --nogpgcheck /tmp/vipm.rpm && rm /tmp/vipm.rpm
+```
+
+**zypper (openSUSE):**
+
+``` { .shell .copy }
+wget -O /tmp/vipm.rpm https://traffic.libsyn.com/secure/jkinc/vipm-26.3.0-3954.x86_64.rpm && sudo zypper --non-interactive install --no-recommends --allow-unsigned-rpm /tmp/vipm.rpm && rm /tmp/vipm.rpm
+```
 
 For more on running VIPM on Linux, see [VIPM on Linux](linux/index.md).
 

--- a/docs/preview.md
+++ b/docs/preview.md
@@ -14,25 +14,25 @@ VIPM previews give you early access to upcoming features before they're included
 
     **Silent install — PowerShell:**
 
-    ```powershell
+    ``` { .powershell .copy }
     $ProgressPreference = 'SilentlyContinue'; Invoke-WebRequest -Uri "https://packages.jki.net/vipm/preview/vipm-setup-latest-preview.exe" -OutFile "$env:TEMP\vipm-setup.exe"; Start-Process -Wait -FilePath "$env:TEMP\vipm-setup.exe" -ArgumentList "/exenoui /qn"; Remove-Item "$env:TEMP\vipm-setup.exe" -Force
     ```
 
     **Silent install — cmd.exe:**
 
-    ```shell
+    ``` { .shell .copy }
     curl.exe -L https://packages.jki.net/vipm/preview/vipm-setup-latest-preview.exe -o %TEMP%\vipm-setup.exe && start /wait %TEMP%\vipm-setup.exe /quiet /norestart && del %TEMP%\vipm-setup.exe
     ```
 
     **Interactive install — PowerShell:**
 
-    ```powershell
+    ``` { .powershell .copy }
     $ProgressPreference = 'SilentlyContinue'; Invoke-WebRequest -Uri "https://packages.jki.net/vipm/preview/vipm-setup-latest-preview.exe" -OutFile "$env:TEMP\vipm-setup.exe"; Start-Process -Wait -FilePath "$env:TEMP\vipm-setup.exe"; Remove-Item "$env:TEMP\vipm-setup.exe" -Force
     ```
 
     **Interactive install — cmd.exe:**
 
-    ```shell
+    ``` { .shell .copy }
     curl.exe -L https://packages.jki.net/vipm/preview/vipm-setup-latest-preview.exe -o %TEMP%\vipm-setup.exe && start /wait %TEMP%\vipm-setup.exe && del %TEMP%\vipm-setup.exe
     ```
 
@@ -43,7 +43,7 @@ VIPM previews give you early access to upcoming features before they're included
 - [Download .deb package](https://packages.jki.net/vipm/preview/vipm_latest_preview_amd64.deb)
 - Or install via command line:
 
-    ```shell
+    ``` { .shell .copy }
     wget -O /tmp/vipm.deb https://packages.jki.net/vipm/preview/vipm_latest_preview_amd64.deb && sudo dpkg -i /tmp/vipm.deb && rm /tmp/vipm.deb
     ```
 
@@ -51,9 +51,24 @@ VIPM previews give you early access to upcoming features before they're included
 
 - [Download .rpm package](https://packages.jki.net/vipm/preview/vipm_latest_preview_amd64.rpm)
 - Or install via command line:
-    - **RHEL 8+ / Fedora / Rocky Linux / AlmaLinux (dnf):** `wget -O /tmp/vipm.rpm https://packages.jki.net/vipm/preview/vipm_latest_preview_amd64.rpm && sudo dnf install -y --nogpgcheck /tmp/vipm.rpm && rm /tmp/vipm.rpm`
-    - **RHEL 7 / CentOS 7 (yum):** `wget -O /tmp/vipm.rpm https://packages.jki.net/vipm/preview/vipm_latest_preview_amd64.rpm && sudo yum install -y --nogpgcheck /tmp/vipm.rpm && rm /tmp/vipm.rpm`
-    - **openSUSE (zypper):** `wget -O /tmp/vipm.rpm https://packages.jki.net/vipm/preview/vipm_latest_preview_amd64.rpm && sudo zypper --non-interactive install --no-recommends --allow-unsigned-rpm /tmp/vipm.rpm && rm /tmp/vipm.rpm`
+
+    **RHEL 8+ / Fedora / Rocky Linux / AlmaLinux (dnf):**
+
+    ``` { .shell .copy }
+    wget -O /tmp/vipm.rpm https://packages.jki.net/vipm/preview/vipm_latest_preview_amd64.rpm && sudo dnf install -y --nogpgcheck /tmp/vipm.rpm && rm /tmp/vipm.rpm
+    ```
+
+    **RHEL 7 / CentOS 7 (yum):**
+
+    ``` { .shell .copy }
+    wget -O /tmp/vipm.rpm https://packages.jki.net/vipm/preview/vipm_latest_preview_amd64.rpm && sudo yum install -y --nogpgcheck /tmp/vipm.rpm && rm /tmp/vipm.rpm
+    ```
+
+    **openSUSE (zypper):**
+
+    ``` { .shell .copy }
+    wget -O /tmp/vipm.rpm https://packages.jki.net/vipm/preview/vipm_latest_preview_amd64.rpm && sudo zypper --non-interactive install --no-recommends --allow-unsigned-rpm /tmp/vipm.rpm && rm /tmp/vipm.rpm
+    ```
 
 ## Feedback
 

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -81,6 +81,39 @@
   width: 1%;
 }
 
+/* Keep copy controls beside, not over, long command text. */
+.md-typeset .highlight.copy > pre {
+  background-color: var(--md-code-bg-color);
+}
+
+.md-typeset .highlight.copy > pre > code {
+  box-sizing: border-box;
+  width: calc(100% - 2.25em);
+  min-width: 0;
+}
+
+.md-typeset .highlight.copy .md-code__button {
+  background-color: var(--md-code-bg-color);
+  color: var(--md-default-fg-color--light);
+  opacity: 0;
+  transition: opacity 150ms ease-in-out;
+}
+
+.md-typeset .highlight.copy:hover .md-code__button {
+  opacity: 1;
+}
+
+@media screen and (max-width: 44.984375em) {
+  .md-content__inner > .highlight.copy {
+    margin-left: 0;
+    margin-right: 0;
+  }
+
+  .md-content__inner > .highlight.copy > pre > code {
+    border-radius: 0.1rem;
+  }
+}
+
 /* Persistent "Download VIPM" call-to-action in the header (every page) */
 .md-header__button.md-download-cta {
   display: inline-flex;


### PR DESCRIPTION
This makes the single-line install commands easier to use without adding copy controls to every code sample on the site.

Closes #121 

## Changes
- Add selective `.copy` markers to stable and preview install command code blocks.
- Convert RPM install one-liners from inline code to fenced command blocks so they can receive copy controls.
- Style copy-enabled blocks so the copy control sits beside the command text, keeps normal mobile page gutters, fades in on hover, and stays hidden otherwise.

## Validation
- `uv run zensical build --strict`