### PR TITLE
Add light and dark theme toggle

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,8 +14,26 @@ theme:
     repo: fontawesome/brands/github
 
   palette:
-    primary: white
-    accent: deep orange
+    - media: "(prefers-color-scheme)"
+      primary: white
+      accent: deep orange
+      toggle:
+        icon: material/brightness-auto
+        name: Switch to light mode
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: white
+      accent: deep orange
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: black
+      accent: deep orange
+      toggle:
+        icon: material/brightness-4
+        name: Switch to system preference
 
   custom_dir: overrides
 


### PR DESCRIPTION
This lets readers use the docs in the color scheme that matches their system preference by default, while still allowing manual light/dark selection from the header.

## Changes
- Convert the single Material palette config into system, light, and dark palette entries.
- Default to Material's automatic mode using `prefers-color-scheme`.
- Preserve the existing white/deep-orange light palette and add a slate dark palette with matching deep-orange accent.
- Add brightness toggle icons for cycling through system preference, light mode, and dark mode.

## Validation
- `uv run zensical build --strict`
- Confirmed rendered pages include the system-preference, light, and dark palette inputs with the expected metadata.