### PR TITLE
Harden docs dev tooling checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,18 +27,28 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
         with:
-          enable-cache: true
+          enable-cache: false
       - name: Set up Python
         run: uv python install
+      - name: Check dependency lockfile
+        run: uv lock --check
       - name: Sync dependencies
-        run: uv sync
+        run: uv sync --locked
       - name: Lint (ruff check)
         run: uv run ruff check
       - name: Format check (ruff format --check)
         run: uv run ruff format --check
+      - name: Type check
+        run: uv run pyrefly check .
+      - name: Lint GitHub Actions workflows
+        run: uv run actionlint
+      - name: Audit GitHub Actions workflows
+        run: uv run zizmor --offline .github/workflows
       - name: Run unit tests
         run: uv run pytest
       - name: Build and validate docs site
@@ -60,18 +70,24 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
         with:
-          enable-cache: true
+          enable-cache: false
       - name: Set up Python
         run: uv python install
+      - name: Check dependency lockfile
+        run: uv lock --check
       - name: Sync dependencies
-        run: uv sync
+        run: uv sync --locked
       - name: Configure git for mike
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
       - name: Generate release-notes table snippet
         run: uv run python scripts/generate_release_notes_table.py
       - name: Generate CLI snippets
@@ -79,25 +95,30 @@ jobs:
       - name: Validate prebuild outputs
         run: uv run python scripts/validate_docs_build.py
       - name: Deploy with mike
+        env:
+          REF: ${{ github.ref }}
+          REF_NAME: ${{ github.ref_name }}
+          SET_LATEST: ${{ github.event.inputs.set_latest }}
+          VERSION_INPUT: ${{ github.event.inputs.version }}
         run: |
           # Determine version label
-          if [ -n "${{ github.event.inputs.version }}" ]; then
-            VERSION="${{ github.event.inputs.version }}"
-          elif [ "${{ github.ref }}" = "refs/heads/main" ]; then
+          if [ -n "$VERSION_INPUT" ]; then
+            VERSION="$VERSION_INPUT"
+          elif [ "$REF" = "refs/heads/main" ]; then
             VERSION="preview"
-          elif [[ "${{ github.ref }}" == refs/heads/release/* ]]; then
+          elif [[ "$REF" == refs/heads/release/* ]]; then
             # Extract version from branch name: release/2026-Q3 -> 2026-Q3
-            VERSION="${{ github.ref_name }}"
+            VERSION="$REF_NAME"
             VERSION="${VERSION#release/}"
           else
-            echo "No deploy rule for ref ${{ github.ref }}"
+            echo "No deploy rule for ref $REF"
             exit 0
           fi
 
           echo "Deploying version: $VERSION"
 
           # Determine if this version should be aliased as "latest"
-          if [ "${{ github.event.inputs.set_latest }}" = "true" ]; then
+          if [ "$SET_LATEST" = "true" ]; then
             uv run mike deploy --push --update-aliases "$VERSION" latest
           elif [ "$VERSION" = "preview" ]; then
             uv run mike deploy --push "$VERSION"

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -19,20 +19,26 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install uv
         if: github.event.action != 'closed'
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
         with:
-          enable-cache: true
+          enable-cache: false
 
       - name: Set up Python
         if: github.event.action != 'closed'
         run: uv python install
 
+      - name: Check dependency lockfile
+        if: github.event.action != 'closed'
+        run: uv lock --check
+
       - name: Sync dependencies
         if: github.event.action != 'closed'
-        run: uv sync
+        run: uv sync --locked
 
       - name: Lint (ruff check)
         if: github.event.action != 'closed'
@@ -40,6 +46,15 @@ jobs:
       - name: Format check (ruff format --check)
         if: github.event.action != 'closed'
         run: uv run ruff format --check
+      - name: Type check
+        if: github.event.action != 'closed'
+        run: uv run pyrefly check .
+      - name: Lint GitHub Actions workflows
+        if: github.event.action != 'closed'
+        run: uv run actionlint
+      - name: Audit GitHub Actions workflows
+        if: github.event.action != 'closed'
+        run: uv run zizmor --offline .github/workflows
       - name: Run unit tests
         if: github.event.action != 'closed'
         run: uv run pytest

--- a/justfile
+++ b/justfile
@@ -23,10 +23,27 @@ format:
 lint:
     uv run ruff check
 
-# no-fix check used before pushing: format check + lint + tests
+# verify pyproject.toml and uv.lock are in sync
+lock:
+    uv lock --check
+
+# run static type checks
+typecheck:
+    uv run pyrefly check .
+
+# lint and audit GitHub Actions workflows
+workflow-check:
+    uv run actionlint
+    uv run zizmor --offline .github/workflows
+
+# no-fix check used before pushing: lockfile, format, lint, types, workflow checks, tests
 check:
+    uv lock --check
     uv run ruff format --check
     uv run ruff check
+    uv run pyrefly check .
+    uv run actionlint
+    uv run zizmor --offline .github/workflows
     uv run pytest
 
 # run unit tests for scripts and validators

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,10 +15,12 @@ dependencies = [
 
 [dependency-groups]
 dev = [
+    "actionlint-py>=1.7.12.24",
     "pyrefly>=1.1.1",
     "pytest>=9.1.1",
     "ruff>=0.15.18",
     "types-pyyaml>=6.0.12.20260518",
+    "zizmor>=1.26.1",
 ]
 
 [tool.pytest.ini_options]

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,12 @@ revision = 3
 requires-python = ">=3.13"
 
 [[package]]
+name = "actionlint-py"
+version = "1.7.12.24"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/0b/3f29683dfbe94208fb5c3806806a6ef419972892e25c3c4f95198f68c978/actionlint_py-1.7.12.24.tar.gz", hash = "sha256:7571b0724fde79b2572b98b2b53792c470249d4db29951b57fc49b9cd3eaf11e", size = 12071, upload-time = "2026-03-31T06:21:35.015Z" }
+
+[[package]]
 name = "click"
 version = "8.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -335,10 +341,12 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "actionlint-py" },
     { name = "pyrefly" },
     { name = "pytest" },
     { name = "ruff" },
     { name = "types-pyyaml" },
+    { name = "zizmor" },
 ]
 
 [package.metadata]
@@ -349,10 +357,12 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "actionlint-py", specifier = ">=1.7.12.24" },
     { name = "pyrefly", specifier = ">=1.1.1" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "ruff", specifier = ">=0.15.18" },
     { name = "types-pyyaml", specifier = ">=6.0.12.20260518" },
+    { name = "zizmor", specifier = ">=1.26.1" },
 ]
 
 [[package]]
@@ -383,4 +393,22 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/91/16/515f81db8055b109a510063be481e60a657c4fad1a883680b2ee4aa9a424/zensical-0.0.46-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:f42a4683c762f026878d19ede4bcf7bfbb84dbecb5ad923949abb77806ed88a5", size = 13369382, upload-time = "2026-06-21T18:52:32.521Z" },
     { url = "https://files.pythonhosted.org/packages/b9/5c/da54ee65b642eb7d88dd4a3db35845d0765915638e05d5d434a10b42f1c3/zensical-0.0.46-cp310-abi3-win32.whl", hash = "sha256:85f018f2a7ee76a83915c87ddb12b58cf343fd6154081d33ac95b6751b011dd7", size = 12354298, upload-time = "2026-06-21T18:52:34.976Z" },
     { url = "https://files.pythonhosted.org/packages/73/26/fc7ef081acbdada8436825221cb728ee84a81d4d78a7bb79aa58bd150d31/zensical-0.0.46-cp310-abi3-win_amd64.whl", hash = "sha256:1543a693a160de60e86ca589592401b584670e7e12c5ae30e3c2ba76786f7ec3", size = 12599687, upload-time = "2026-06-21T18:52:37.913Z" },
+]
+
+[[package]]
+name = "zizmor"
+version = "1.26.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/a0/a29b38e24981b4bb41db4f292b2c9fb9ddf8b05d6b724abddd7bd108b621/zizmor-1.26.1.tar.gz", hash = "sha256:0c2cc575007a4db99d89d5acc6120cfa7b61504bc2394c3b50af348c73f1916e", size = 535275, upload-time = "2026-06-21T02:47:21.265Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/40/a9/2f47f7db8db9491025e00a7f1a0f25d32b642c0285b2fe070ac63e679b47/zizmor-1.26.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:7ea21ca959c8e888de238fee81d73a1fdf89a82067eac75b8f1acdbd23e2eeaf", size = 9086061, upload-time = "2026-06-21T02:46:57.492Z" },
+    { url = "https://files.pythonhosted.org/packages/58/92/cf6801f01e1d65cbda89a2e2926ea42caf1daad9ffa3f1fc88e4c68f48a9/zizmor-1.26.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:78083b495593f8b0b9dec14036a0836a5afcddda8a40738336ff4e399476b741", size = 8626865, upload-time = "2026-06-21T02:47:00.323Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/b1/ff38fc2921f1fb13244bb3a3642c4b45ecf3946c279942aafcb5dbf55a57/zizmor-1.26.1-py3-none-manylinux_2_24_aarch64.whl", hash = "sha256:bb7ebbe565a3742eb49a590352127ad549bb122b9b4ff9424ebab7525fa3b6b6", size = 8843965, upload-time = "2026-06-21T02:47:03.318Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/06/c07fd0eeef0427d93e99d552d5386526fbcd0bf05fc95cd37bdc6229fccb/zizmor-1.26.1-py3-none-manylinux_2_28_armv7l.whl", hash = "sha256:d3049010b6bd6f849413b6d20c28e0c677b90e0a5b2bc73cbee7f7bd86dc5828", size = 8386985, upload-time = "2026-06-21T02:47:05.741Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/2b/61ab13d45d6ce57ef5a08bb3246981f62e30bb4938098b17bb7b88110b79/zizmor-1.26.1-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:6a958d8a0941d7e1d0de8436670b5cb7fc64c8028b4d16e3f519ccc77f953cef", size = 9257232, upload-time = "2026-06-21T02:47:07.941Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/ad/bd74a96cb02045414ec5b573cd97ff3b82a97fd0bd6658f93c36a011c439/zizmor-1.26.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:d2744cdf944436ca7a009ae8b626a017a40381ec990216abd6cf6b8beb23323a", size = 8873798, upload-time = "2026-06-21T02:47:10.472Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/7e/fb3d608ee11e2f619d43ad93bab46eb7b32769fa82b1d86fd23f27c2585b/zizmor-1.26.1-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:44099f426af9da750ff9f548a0084e11d7d83e0158fe1a2778672398d728efdd", size = 8350857, upload-time = "2026-06-21T02:47:12.748Z" },
+    { url = "https://files.pythonhosted.org/packages/27/cc/82d7a838c2d490071555c364f90eb851044b3eeefc1d68612179a2cd1ae5/zizmor-1.26.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:8313cc264dec792f00a7328eb7c8e89e7d62d54f950fc897d1e6a5a6e5762203", size = 9351148, upload-time = "2026-06-21T02:47:14.777Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/ee/d2a2301f30b9e1bf0d721bfd31739acd71e048757f9ba79279583eb30ac0/zizmor-1.26.1-py3-none-win32.whl", hash = "sha256:c96d7787d69fb298eae939e00dfdf7f534d7dfbd9cc17ab442c0650a56851415", size = 7531021, upload-time = "2026-06-21T02:47:17.247Z" },
+    { url = "https://files.pythonhosted.org/packages/91/58/ad561f3a5057d3c0f152002e180a3a5745e72ea9d69bf66450ef9f5d3fe5/zizmor-1.26.1-py3-none-win_amd64.whl", hash = "sha256:0a05acf6068609fb6df3b137276cf18a686226a1e0e207941cb34a85929f16cf", size = 8616584, upload-time = "2026-06-21T02:47:19.094Z" },
 ]


### PR DESCRIPTION
This makes the docs repo's standard validation catch type-checking, lockfile drift, and GitHub Actions issues before changes merge.

## Changes
- Add actionlint-py and zizmor as dev dependencies.
- Add just recipes for lockfile, type, and workflow checks.
- Expand just check to include uv lock --check, Pyrefly, actionlint, and zizmor.
- Mirror the new checks in CI and PR preview workflows.
- Use locked uv syncs in CI.
- Harden workflows by disabling persisted checkout credentials where possible, disabling uv cache, and avoiding direct template expansion in deploy shell logic.

## Validation
- uv sync --locked
- uv run actionlint
- uv run zizmor --offline .github/workflows
- just check
- just build