### PR TITLE
Add one-click latest docs republish workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,23 @@ on:
         required: false
         default: 'false'
         type: boolean
+  workflow_call:
+    inputs:
+      version:
+        description: 'Version label to deploy'
+        required: false
+        default: ''
+        type: string
+      set_latest:
+        description: 'Set the deployed version as latest'
+        required: false
+        default: false
+        type: boolean
+      republish_current_latest:
+        description: 'Republish main to the version currently aliased as latest'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   build:
@@ -26,11 +43,13 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      # v7.0.0 -> 9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           persist-credentials: false
       - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+        # v8.2.0 -> fac544c07dec837d0ccb6301d7b5580bf5edae39
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
         with:
           enable-cache: false
       - name: Set up Python
@@ -54,7 +73,8 @@ jobs:
       - name: Build and validate docs site
         run: uv run python scripts/build_docs.py
       - name: Upload site artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        # v7.0.1 -> 043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: site-pr-${{ github.event.pull_request.number || github.run_number }}
           path: site/
@@ -67,12 +87,14 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      # v7.0.0 -> 9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           fetch-depth: 0
           persist-credentials: false
       - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+        # v8.2.0 -> fac544c07dec837d0ccb6301d7b5580bf5edae39
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
         with:
           enable-cache: false
       - name: Set up Python
@@ -96,13 +118,25 @@ jobs:
         run: uv run python scripts/validate_docs_build.py
       - name: Deploy with mike
         env:
+          REPUBLISH_CURRENT_LATEST: ${{ inputs.republish_current_latest }}
           REF: ${{ github.ref }}
           REF_NAME: ${{ github.ref_name }}
-          SET_LATEST: ${{ github.event.inputs.set_latest }}
-          VERSION_INPUT: ${{ github.event.inputs.version }}
+          SET_LATEST: ${{ inputs.set_latest }}
+          VERSION_INPUT: ${{ inputs.version }}
         run: |
           # Determine version label
-          if [ -n "$VERSION_INPUT" ]; then
+          if [ "$REPUBLISH_CURRENT_LATEST" = "true" ]; then
+            git fetch origin gh-pages
+            VERSION="$(
+              git show origin/gh-pages:versions.json |
+                jq -er '
+                  [.[] | select((.aliases // []) | index("latest")) | .version]
+                  | if length == 1 then .[0]
+                    else error("expected exactly one version aliased as latest")
+                    end
+                '
+            )"
+          elif [ -n "$VERSION_INPUT" ]; then
             VERSION="$VERSION_INPUT"
           elif [ "$REF" = "refs/heads/main" ]; then
             VERSION="preview"
@@ -118,7 +152,7 @@ jobs:
           echo "Deploying version: $VERSION"
 
           # Determine if this version should be aliased as "latest"
-          if [ "$SET_LATEST" = "true" ]; then
+          if [ "$REPUBLISH_CURRENT_LATEST" = "true" ] || [ "$SET_LATEST" = "true" ]; then
             uv run mike deploy --push --update-aliases "$VERSION" latest
           elif [ "$VERSION" = "preview" ]; then
             uv run mike deploy --push "$VERSION"

--- a/.github/workflows/republish-latest.yml
+++ b/.github/workflows/republish-latest.yml
@@ -1,0 +1,19 @@
+name: Republish current latest docs
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: republish-current-latest-docs
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  republish:
+    permissions:
+      contents: write
+    uses: ./.github/workflows/ci.yml
+    with:
+      republish_current_latest: true

--- a/dev-docs/versioned-docs.md
+++ b/dev-docs/versioned-docs.md
@@ -73,6 +73,16 @@ This is used for:
 - Redeploying a hotfix to an existing version
 - Bootstrapping historical versions
 
+### Republish the current `latest` version
+
+Use the **Republish current latest docs** workflow to publish the current `main`
+branch to whichever release version already owns the `latest` alias. This workflow
+has no inputs: select **Run workflow** and confirm the run.
+
+The workflow reads `versions.json` from `gh-pages`, requires exactly one version to
+own the `latest` alias, and republishes that version while preserving the alias. Use
+the general **ci** workflow instead when changing which release is `latest`.
+
 ### PR builds
 
 Pull requests build without deploying any version. The `pr-preview-action` in `preview.yml` handles ephemeral PR previews separately. (Zensical 0.0.x does not yet support a `--strict` mode, so CI cannot fail on warnings the way the MkDocs-era pipeline did.)
@@ -161,4 +171,5 @@ Hotfixes to shipped docs are committed to the maintenance branch and CI redeploy
 | `mkdocs.yml` | `extra.version` enables the version switcher |
 | `pyproject.toml` | `mike` dependency |
 | `.github/workflows/ci.yml` | Deploy logic (auto + manual) |
+| `.github/workflows/republish-latest.yml` | One-click republish of `main` to the current `latest` release |
 | `.github/workflows/preview.yml` | PR preview deploys (unchanged) |


### PR DESCRIPTION
Republishing current documentation to `/latest/` currently requires an operator to inspect the Mike alias target and enter multiple deployment inputs. This adds a no-input workflow for that routine operation while preserving the existing explicit-version workflow for releases.

## Changes
- Add a **Republish current latest docs** workflow that calls the existing validated deployment workflow.
- Resolve the current `latest` target from `gh-pages/versions.json` and fail unless exactly one version owns the alias.
- Republish `main` to that version while preserving the `latest` alias.
- Document the one-click workflow and retain the general workflow for changing the latest release.
- Update actions used by the modified CI workflow to their latest immutable release SHAs.

## Validation
- `just check`
- `just build`
- Verified alias resolution against current Mike metadata (`2026-Q3`).
- Verified missing and duplicate alias metadata fail closed.
