### PR TITLE
Add Renovate dependency automation

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended", "helpers:pinGitHubActionDigests"],
+  "dependencyDashboard": true,
+  "configMigration": true,
+  "labels": ["dependencies"],
+  "timezone": "America/Los_Angeles",
+  "schedule": ["* 4-8 * * 1"],
+  "prConcurrentLimit": 3,
+  "prHourlyLimit": 1,
+  "rangeStrategy": "bump",
+  "enabledManagers": ["github-actions", "pep621", "renovate-config"],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["* 4-8 * * 1"]
+  },
+  "packageRules": [
+    {
+      "description": "Keep Python runtime upgrades deliberate.",
+      "matchManagers": ["pep621"],
+      "matchDepTypes": ["requires-python"],
+      "enabled": false
+    },
+    {
+      "description": "Group non-major Python runtime dependency updates.",
+      "matchManagers": ["pep621"],
+      "matchDepTypes": ["project.dependencies"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "Python runtime dependencies"
+    },
+    {
+      "description": "Group non-major Python dev dependency updates.",
+      "matchManagers": ["pep621"],
+      "matchDepTypes": ["dependency-groups"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "Python dev dependencies"
+    },
+    {
+      "description": "Group non-major GitHub Actions updates.",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["minor", "patch", "digest", "pin"],
+      "groupName": "GitHub Actions"
+    }
+  ]
+}


### PR DESCRIPTION
Dependency updates are currently manual, which makes routine Python and GitHub Actions maintenance easy to defer. This adds bounded weekly automation without enabling automatic merges.

## Changes
- Add a validated Renovate config for PEP 621/uv dependencies, GitHub Actions, and Renovate config updates.
- Run Renovate weekly on Monday mornings in the project timezone.
- Group non-major Python runtime, Python dev, and GitHub Actions updates.
- Keep major updates separate and Python runtime upgrades deliberate.
- Enable weekly lockfile maintenance and the dependency dashboard.
- Pin GitHub Actions to immutable digests.
- Limit Renovate to three concurrent PRs and one new PR per hour.

## Validation
- `npx --yes --package renovate -- renovate-config-validator`
- `just check`
- `just build`