### PR TITLE
Add 2026.3.1 Preview release notes

### DIFF
--- a/docs/release-notes/2026.3.1.md
+++ b/docs/release-notes/2026.3.1.md
@@ -1,0 +1,14 @@
+---
+title: VIPM 2026 Q3 f1 Preview
+description: Preview release addressing Linux file path handling for VI package builds and a LabVIEW architecture mismatch in SBOM generation.
+---
+
+!!! tip "Preview Release"
+    This is a preview release. See [VIPM Preview](https://docs.vipm.io/latest/preview/) for instructions on how to obtain and install this preview build.
+
+VIPM 2026 Q3 f1 is a preview release addressing file path handling on Linux and a LabVIEW architecture mismatch during SBOM generation.
+
+## Fixes
+
+- **Linux file path handling**: Resolved issues with file path handling on Linux so that building VI packages works correctly, including `.vipb` files created on Windows that previously lost their path information when opened on Linux. See the [tracking issue #132](https://github.com/vipm-io/vipm-desktop-issues/issues/132).
+- **SBOM architecture mismatch**: Resolved an issue where generated SBOMs could attribute LabVIEW library VIs (from `vi.lib` or `instr.lib`) to the wrong NIPM package or the wrong architecture (32-bit vs 64-bit). See the [tracking issue #133](https://github.com/vipm-io/vipm-desktop-issues/issues/133).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -109,6 +109,7 @@ nav:
       - linux/permissions-guide.md
   - Release Notes:
     - release-notes/index.md
+    - release-notes/2026.3.1.md
     - release-notes/2026.3.md
     - release-notes/2026.1.md
     - release-notes/2025.3.1.md


### PR DESCRIPTION
VIPM 2026.3.1 is a preview fix release; this publishes its release-notes page so users on the preview docs can see what changed.

- Adds `docs/release-notes/2026.3.1.md` covering the Linux file-path-handling fix for VI package builds and the SBOM wrong-attribution fix for LabVIEW library VIs, each linking its public tracking issue.
- Registers the page in the `mkdocs.yml` nav (newest-first), titled "2026.3.1 Preview".