### PR TITLE
Replace Preview Documentation callout with current preview release pointer

### DIFF
--- a/docs/preview.md
+++ b/docs/preview.md
@@ -2,8 +2,8 @@
 
 VIPM previews give you early access to upcoming features before they're included in a stable release.
 
-!!! tip "Preview Documentation"
-    Full documentation for preview features is available at [docs.vipm.io/preview](https://docs.vipm.io/preview/).
+!!! tip "Latest Preview Release"
+    [VIPM 2026 Q3 f1 Preview](release-notes/2026.3.1.md) is the latest preview release — see its release notes for what's new.
 
 ## Installation
 


### PR DESCRIPTION
Gives readers landing on the Preview Releases page a clear next step ("here's what's actually in this preview") instead of the previous self-referential pointer to the preview docs alias.

## Changes

`docs/preview.md`: replace the `!!! tip "Preview Documentation"` callout with a `!!! tip "Latest Preview Release"` callout that names the current preview release and links directly to its release notes.

Before:
> **Preview Documentation**
> Full documentation for preview features is available at [docs.vipm.io/preview](https://docs.vipm.io/preview/).

After:
> **Latest Preview Release**
> [VIPM 2026 Q3 f1 Preview](https://docs.vipm.io/latest/release-notes/2026.3.1/) is the latest preview release — see its release notes for what's new.

## Maintenance note

This callout now names a specific release and will need to be updated each time a new preview ships. If that becomes routine, a small generator (analogous to the release-notes table) could keep it current automatically.