### PR TITLE
Serialize gh-pages deploys with a job-level concurrency group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,14 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    # Serialize gh-pages pushes across every invocation path of this workflow
+    # (push to main, push to release/*, workflow_dispatch, and workflow_call
+    # from republish-latest.yml). Without this, two `mike deploy --push` runs
+    # can race and the loser is rejected ("cannot lock ref refs/heads/gh-pages"),
+    # leaving one alias (preview or latest) un-updated.
+    concurrency:
+      group: gh-pages-deploy
+      cancel-in-progress: false
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
Fixes a race where the push-to-main \`ci.yml\` deploy and \`republish-latest.yml\` (which calls into \`ci.yml\`) can both push to \`gh-pages\` concurrently — the second push is rejected with \`cannot lock ref 'refs/heads/gh-pages'\` and that deploy fails, leaving one alias (preview or latest) un-updated.

Hit this in practice: merging a docs PR + triggering republish-latest immediately after raced, the preview-alias deploy lost the push, and the failed run had to be re-run by hand once gh-pages settled.

## Change

Add a job-level \`concurrency\` group on the \`deploy\` job in \`ci.yml\`:

\`\`\`yaml
concurrency:
  group: gh-pages-deploy
  cancel-in-progress: false
\`\`\`

- **Job-level, not workflow-level**, so the \`build\` job still runs in parallel — only the actual \`mike deploy --push\` step serializes.
- **Same group across invocation paths.** A job-level concurrency group on the called workflow's job naturally covers both direct \`push\` and \`workflow_call\` (from \`republish-latest.yml\`) invocations of \`ci.yml\`.
- **\`cancel-in-progress: false\`** queues rather than cancels — important so an in-flight \`mike\` push isn't aborted mid-way and we don't leave \`gh-pages\` partially updated.

## Notes

- \`republish-latest.yml\` already has its own workflow-level concurrency group (\`republish-current-latest-docs\`) that serializes republish-latest against itself. That stays as-is; it now composes with the new job-level group.
- No new permissions, no new actions. Pure scheduling fix.