### PR TITLE
Group 2026.3.1 release notes by build number

### DIFF
--- a/docs/release-notes/2026.3.1.md
+++ b/docs/release-notes/2026.3.1.md
@@ -8,7 +8,9 @@ description: Preview release addressing Linux file path handling for VI package 
 
 VIPM 2026 Q3 f1 is a preview release addressing file path handling on Linux and a LabVIEW architecture mismatch during SBOM generation.
 
-## Fixes
+## Build 3977
+
+### Fixes
 
 - **Linux file path handling**: Resolved issues with file path handling on Linux so that building VI packages works correctly, including `.vipb` files created on Windows that previously lost their path information when opened on Linux. See the [tracking issue #132](https://github.com/vipm-io/vipm-desktop-issues/issues/132).
 - **SBOM architecture mismatch**: Resolved an issue where generated SBOMs could attribute LabVIEW library VIs (from `vi.lib` or `instr.lib`) to the wrong NIPM package or the wrong architecture (32-bit vs 64-bit). See the [tracking issue #133](https://github.com/vipm-io/vipm-desktop-issues/issues/133).


### PR DESCRIPTION
Make build number the primary grouping on the 2026.3.1 release-notes page so subsequent preview/patch builds each get their own section. The two current fixes are in build 3977.

## Change

`docs/release-notes/2026.3.1.md`: replace `## Fixes` with `## Build 3977` + `### Fixes` under it (using H2 for build, H3 for change type).

Before:
\`\`\`
## Fixes
- Linux file path handling...
- SBOM architecture mismatch...
\`\`\`

After:
\`\`\`
## Build 3977

### Fixes
- Linux file path handling...
- SBOM architecture mismatch...
\`\`\`

## Why this shape (build at H2, change-type at H3)

A future build that ships features alongside fixes can just add `### New Features` under its own `## Build N` section without restructuring the page. The alternative — `## Fixes → ### Build N`, `## New Features → ### Build N` — would force each build to appear under every change-type section, duplicating the build header across the page.