### PR TITLE
Cross-link 2026.3 and 2026.3.1 release notes

### DIFF
--- a/docs/release-notes/2026.3.1.md
+++ b/docs/release-notes/2026.3.1.md
@@ -6,7 +6,7 @@ description: Preview release addressing Linux file path handling for VI package 
 !!! tip "Preview Release"
     This is a preview release. See [VIPM Preview](https://docs.vipm.io/latest/preview/) for instructions on how to obtain and install this preview build.
 
-VIPM 2026 Q3 f1 is a preview release addressing file path handling on Linux and a LabVIEW architecture mismatch during SBOM generation.
+VIPM 2026 Q3 f1 is a preview release that builds upon [VIPM 2026 Q3](2026.3.md) and addresses issues related to file path handling on Linux and a LabVIEW architecture mismatch during SBOM generation.
 
 ## Build 3977
 

--- a/docs/release-notes/2026.3.md
+++ b/docs/release-notes/2026.3.md
@@ -199,4 +199,8 @@ See the [tracking issue](https://github.com/vipm-io/vipm-desktop-issues/issues/8
 - [CLI] `vipm install` from a `vipm.toml` with many already-installed dependencies now reports them as a single summary line instead of one notice per package; pass `--verbose` for the full per-package plan.
 - [CLI] `vipm sbom` and `vipm sync` no longer fail on a machine where VIPM Desktop has never run (for example, a CI runner or fresh install): an absent VIPM package database is now treated as "no installed packages", so the scan proceeds with a warning instead of aborting.
 
+## Newer releases
+
+- [VIPM 2026 Q3 f1 Preview](2026.3.1.md) — fixes for Linux file path handling and SBOM architecture attribution.
+
 --8<-- "need-help.md"


### PR DESCRIPTION
Readers landing on either the stable 2026 Q3 release notes or the 2026.3.1 preview release notes currently have no in-page signal of the other. Add a bidirectional cross-link so readers in either direction can navigate to the related release.

## Changes

Two commits, one per direction:

1. **`2026.3.md` → adds a "Newer releases" section.** Before the trailing `--8<-- "need-help.md"` snippet, append:

   ```markdown
   ## Newer releases

   - [VIPM 2026 Q3 f1 Preview](2026.3.1.md) — fixes for Linux file path handling and SBOM architecture attribution.
   ```

2. **`2026.3.1.md` → reframes the intro paragraph to link back to 2026.3.** Change the intro from:

   > VIPM 2026 Q3 f1 is a preview release addressing file path handling on Linux and a LabVIEW architecture mismatch during SBOM generation.

   to:

   > VIPM 2026 Q3 f1 is a preview release that builds upon [VIPM 2026 Q3](2026.3.md) and addresses issues related to file path handling on Linux and a LabVIEW architecture mismatch during SBOM generation.

## Convention

This establishes a new pattern: a stable release-notes page links to its subsequent preview/patch pages in a "Newer releases" section at the bottom, and each preview/patch page's intro links back to its stable predecessor. If accepted, the same pattern can be retroactively applied to earlier stable releases (e.g. `2025.3.md ↔ 2025.3.1.md`).