### PR TITLE
Link 2026.3 and 2026.3.1 release notes to their public milestones

### DIFF
--- a/docs/release-notes/2026.3.1.md
+++ b/docs/release-notes/2026.3.1.md
@@ -14,3 +14,7 @@ VIPM 2026 Q3 f1 is a preview release that builds upon [VIPM 2026 Q3](2026.3.md) 
 
 - **Linux file path handling**: Resolved issues with file path handling on Linux so that building VI packages works correctly, including `.vipb` files created on Windows that previously lost their path information when opened on Linux. See the [tracking issue #132](https://github.com/vipm-io/vipm-desktop-issues/issues/132).
 - **SBOM architecture mismatch**: Resolved an issue where generated SBOMs could attribute LabVIEW library VIs (from `vi.lib` or `instr.lib`) to the wrong NIPM package or the wrong architecture (32-bit vs 64-bit). See the [tracking issue #133](https://github.com/vipm-io/vipm-desktop-issues/issues/133).
+
+## Tracked issues
+
+See the [2026 Q3 f1 milestone](https://github.com/vipm-io/vipm-desktop-issues/milestone/5) for all issues tracked for this release.

--- a/docs/release-notes/2026.3.md
+++ b/docs/release-notes/2026.3.md
@@ -203,4 +203,8 @@ See the [tracking issue](https://github.com/vipm-io/vipm-desktop-issues/issues/8
 
 - [VIPM 2026 Q3 f1 Preview](2026.3.1.md) — fixes for Linux file path handling and SBOM architecture attribution.
 
+## Tracked issues
+
+See the [2026 Q3 milestone](https://github.com/vipm-io/vipm-desktop-issues/milestone/4) for all issues tracked for this release.
+
 --8<-- "need-help.md"


### PR DESCRIPTION
Readers landing on a release-notes page have no in-page link to the broader set of issues tracked for that release. Restore the public-milestone link convention used on 2023.1.md and 2023.3.md (which lapsed on more recent release pages) for 2026.3 and 2026.3.1.

## Changes

Add a "Tracked issues" section to both pages, linking the corresponding milestone in `vipm-io/vipm-desktop-issues`:

- `2026.3.md` → links [milestone #4 "2026 Q3"](https://github.com/vipm-io/vipm-desktop-issues/milestone/4)
- `2026.3.1.md` → links [milestone #5 "2026 Q3 f1"](https://github.com/vipm-io/vipm-desktop-issues/milestone/5)

Placement is at the bottom of each page (next to the "Newer releases" section on 2026.3.md; as the final section on 2026.3.1.md).

## Note on the URL filter

The 2023.x precedent appended `?closed=1` to the milestone URLs to show only fixed issues. That works for fully-shipped milestones but renders empty when (as with milestone 4 "2026 Q3") the milestone is closed yet a tracking issue is still open because its full fix landed in a subsequent release. Drop the filter so all issues regardless of state are visible.

## Scope

This PR touches only the 2026.3 pair. The convention could be applied retroactively to 2024.1, 2024.3, 2025.3, 2025.3.1, and 2026.1 in a follow-up PR after spot-checking that each has a corresponding public milestone.