### PR TITLE
Add Save Version edition fix to 2026.3.1 release notes

### DIFF
--- a/docs/release-notes/2026.3.1.md
+++ b/docs/release-notes/2026.3.1.md
@@ -1,12 +1,19 @@
 ---
 title: VIPM 2026 Q3 f1 Preview
-description: Preview release addressing Linux file path handling for VI package builds and a LabVIEW architecture mismatch in SBOM generation.
+description: Preview release making the VI Package Builder Save Version feature available in Community and Pro, plus Linux file path handling for VI package builds and a LabVIEW architecture mismatch in SBOM generation.
 ---
 
 !!! tip "Preview Release"
     This is a preview release. See [VIPM Preview](https://docs.vipm.io/latest/preview/) for instructions on how to obtain and install this preview build.
 
-VIPM 2026 Q3 f1 is a preview release that builds upon [VIPM 2026 Q3](2026.3.md) and addresses issues related to file path handling on Linux and a LabVIEW architecture mismatch during SBOM generation.
+VIPM 2026 Q3 f1 is a preview release that builds upon [VIPM 2026 Q3](2026.3.md) and addresses the VI Package Builder Save Version preview feature being unavailable outside Professional Edition, file path handling on Linux, and a LabVIEW architecture mismatch during SBOM generation.
+
+<!-- Replace "TBD" with the build number once the preview build containing this fix is cut. -->
+## Build TBD
+
+### Fixes
+
+- **"Save Version" available in Community and Pro**: Resolved an issue where the VI Package Builder **Save Version** preview feature always reported a Professional-Edition-only error regardless of your edition, which blocked the feature for everyone. It is now available in **Community Edition** (non-commercial use) and **Professional Edition**. See the [tracking issue #136](https://github.com/vipm-io/vipm-desktop-issues/issues/136).
 
 ## Build 3977
 


### PR DESCRIPTION
## Why

The VI Package Builder **"Save Version"** preview feature was unusable in VIPM 2026 Q3 (2026.3.0) Preview — it always reported a Professional-Edition-only error regardless of the user's edition, blocking the feature for everyone. VIPM 2026 Q3 f1 fixes this so the feature works in Community Edition (non-commercial) and Professional Edition. The public release notes need to reflect the fix.

## Changes

- Add a **"Save Version" available in Community and Pro** entry to the 2026 Q3 f1 release notes under a new build section.
- Update the page intro and the frontmatter `description` to include this fix.

## Note

The new build section is labeled **Build TBD** — the build number for the preview build containing this fix is not yet assigned. Replace "TBD" with the actual build number before this is merged/published. References tracking issue vipm-io/vipm-desktop-issues#136.
