### PR TITLE
Fill in build 4017 on the 2026 Q3 f1 release notes

### DIFF
--- a/docs/release-notes/2026.3.1.md
+++ b/docs/release-notes/2026.3.1.md
@@ -8,8 +8,7 @@ description: Preview release with SBOM accuracy and CLI reliability improvements
 
 VIPM 2026 Q3 f1 is a preview release that builds upon [VIPM 2026 Q3](2026.3.md) with SBOM accuracy and CLI reliability improvements, makes the VI Package Builder Save Version preview feature available outside Professional Edition, and continues the Linux file path handling fixes.
 
-<!-- Replace "TBD" with the build number once the preview build containing this fix is cut. -->
-## Build TBD
+## Build 4017
 
 ### Improvements
 

--- a/docs/release-notes/2026.3.md
+++ b/docs/release-notes/2026.3.md
@@ -9,7 +9,7 @@ VIPM 2026 Q3 adds Software Bill of Materials (SBOM) generation, project synchron
 
 Many of the new features and capabilities are visible in the `vipm` command-line interface (CLI).
 
-## Software Bill of Materials (SBOM) wtih `vipm sbom` CLI Command
+## Software Bill of Materials (SBOM) with `vipm sbom` CLI Command
 
 Generate [CycloneDX](https://cyclonedx.org/) 1.5 SBOMs from LabVIEW projects, vipm.toml manifests, `.vipc`, or `.dragon` files. SBOMs include both VIPM and NI packages with enriched metadata, license identifiers, and cryptographic hashes — helping meet compliance requirements such as the EU Cyber Resilience Act and US Executive Order 14028.
 


### PR DESCRIPTION
The 2026 Q3 f1 preview has been published as build 4017, so the release notes should name the actual build instead of the placeholder.

- Replace the "Build TBD" heading (and its editing note) with "Build 4017" on the 2026 Q3 f1 release notes
- Fix a typo in the 2026 Q3 release notes SBOM heading ("wtih" -> "with")