### PR TITLE
Document native SBOM custom component declarations in vipm.toml

### DIFF
--- a/docs/sbom/custom-components.md
+++ b/docs/sbom/custom-components.md
@@ -68,7 +68,7 @@ so declarations do not apply there.
 | `supplier` | no | Supplier as `Name <email>` or a bare organization name. |
 | `description` | no | Human-readable description. |
 | `homepage` | no | Project or vendor URL, emitted as a `website` external reference. |
-| `depends-on` | no | Dependency references to other components in the SBOM — see below. |
+| `depends-on` | no | Dependency references to other components in the SBOM, by name or purl — see below. |
 
 Declarations are validated when the manifest is loaded: a missing `name`, an unknown `type`, an
 invalid `purl`, a duplicate declaration, or a blank field fails the command with a message naming
@@ -77,15 +77,17 @@ every problem, so a bad declaration can never produce a silently wrong SBOM.
 ### Declaring dependencies between components
 
 The `depends-on` field records that a component depends on other components in the SBOM — either
-discovered packages or other declared components — by name, or by `name@version` when several
-versions are present:
+discovered packages or other declared components. Reference a component by name, by `name@version`
+when several versions are present, or by its purl (`pkg:...`) when even the name and version are
+shared — for example, two components that legitimately carry the same name and version under
+different purls:
 
 ```toml
 [[sbom.component]]
 name = "motor-controller-firmware"
 version = "3.2.0"
 type = "firmware"
-depends-on = ["libusb@1.0.27", "oglib_error"]
+depends-on = ["libusb@1.0.27", "oglib_error", "pkg:generic/vendor-runtime@2.1.0"]
 ```
 
 These references become edges in the SBOM's dependency graph (CycloneDX `dependencies`). A reference

--- a/docs/sbom/custom-components.md
+++ b/docs/sbom/custom-components.md
@@ -6,57 +6,132 @@ title: Custom Components
 
 ## Background
 
-`vipm sbom` automatically discovers VIPM and NIPM packages in your project, but LabVIEW applications can depend on components that neither package manager tracks — DLLs, firmware, hardware modules, and other third-party artifacts.
+`vipm sbom` automatically discovers VIPM and NIPM packages in your project, but LabVIEW applications
+can depend on components that neither package manager tracks — DLLs called through Call Library
+Function nodes, firmware images, hardware drivers, vendor SDKs, and other third-party artifacts.
+Compliance frameworks expect the SBOM to account for **all** third-party components, not only the
+package-manager-tracked subset.
 
-The recommended approach is to maintain a separate CycloneDX file for these components and merge it with the `vipm sbom` output using standard CycloneDX merge tooling.
+Declare these components once in your `vipm.toml`, and every SBOM you generate from that manifest
+includes them — deduplicated against discovered packages, deterministically ordered, and marked with
+their origin.
 
-## Merge the `vipm sbom` output with a supplemental SBOM
+!!! tip "Never edit generated SBOM files"
 
-One practical approach is to maintain a hand-crafted CycloneDX JSON file containing your custom components and merge it with the output of `vipm sbom`.
+    A generated SBOM is a pure output: it is rebuilt from your manifest, lock file, and project
+    sources every time, so hand-edits are destroyed on the next run and break the document's
+    verifiability. Add or change components in `vipm.toml` and regenerate instead.
 
-**Step 1** — Generate your LabVIEW SBOM as usual:
+## Declaring components
 
-```bash
-vipm sbom MyProject.lvproj \
-  --format cyclonedx \
-  --schema-version 1.5 \
-  --product-name "My Application" \
-  --product-version 1.0.0 \
-  --output build/labview-bom.json
+Add one `[[sbom.component]]` block per component to your `vipm.toml`:
+
+```toml
+[[sbom.component]]
+name = "libusb"
+version = "1.0.27"
+type = "library"
+purl = "pkg:github/libusb/libusb@1.0.27"
+license = "LGPL-2.1-or-later"
+supplier = "libusb contributors"
+description = "Cross-platform USB access library"
+homepage = "https://libusb.info"
+
+[[sbom.component]]
+name = "motor-controller-firmware"
+version = "3.2.0"
+type = "firmware"
+supplier = "Acme Motion Inc."
+depends-on = ["libusb@1.0.27"]
 ```
 
-**Step 2** — Create a supplemental SBOM file (`custom-components.json`) with your additional components:
-
-```json
-{
-  "bomFormat": "CycloneDX",
-  "specVersion": "1.5",
-  "version": 1,
-  "components": [
-    {
-      "type": "library",
-      "name": "libusb",
-      "version": "1.0.27",
-      "purl": "pkg:github/libusb/libusb@v1.0.27",
-      "licenses": [
-        { "license": { "id": "LGPL-2.1-or-later" } }
-      ]
-    }
-  ]
-}
-```
-
-**Step 3** — Merge the two files using the [CycloneDX CLI](https://github.com/CycloneDX/cyclonedx-cli):
+Then generate as usual:
 
 ```bash
+vipm sbom vipm.toml --format cyclonedx --output build/bom.json
+```
+
+Declared components apply to manifest-backed generation — `vipm sbom` with a `vipm.toml` input.
+Generating directly from a `.lvproj` file scans the project itself and does not read any manifest,
+so declarations do not apply there.
+
+### Field reference
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | yes | Component name as it should appear in the SBOM. |
+| `version` | no | Component version. When absent, the component is emitted without a version field. |
+| `type` | no | CycloneDX component type: `application`, `container`, `data`, `device`, `device-driver`, `file`, `firmware`, `framework`, `library` (default), `machine-learning-model`, `operating-system`, or `platform`. |
+| `purl` | no | [Package URL](https://github.com/package-url/purl-spec) identifying the component. Validated when the manifest is loaded and emitted in canonical form. If it carries a version segment, it must agree with `version`. |
+| `cpe` | no | CPE identifier for vulnerability correlation. |
+| `license` | no | SPDX license identifier (emitted as a license `id`) or a free-form license name (emitted as a license `name`). |
+| `supplier` | no | Supplier as `Name <email>` or a bare organization name. |
+| `description` | no | Human-readable description. |
+| `homepage` | no | Project or vendor URL, emitted as a `website` external reference. |
+| `depends-on` | no | Dependency references to other components in the SBOM — see below. |
+
+Declarations are validated when the manifest is loaded: a missing `name`, an unknown `type`, an
+invalid `purl`, a duplicate declaration, or a blank field fails the command with a message naming
+every problem, so a bad declaration can never produce a silently wrong SBOM.
+
+### Declaring dependencies between components
+
+The `depends-on` field records that a component depends on other components in the SBOM — either
+discovered packages or other declared components — by name, or by `name@version` when several
+versions are present:
+
+```toml
+[[sbom.component]]
+name = "motor-controller-firmware"
+version = "3.2.0"
+type = "firmware"
+depends-on = ["libusb@1.0.27", "oglib_error"]
+```
+
+These references become edges in the SBOM's dependency graph (CycloneDX `dependencies`). A reference
+that matches nothing in the generated SBOM — or that ambiguously matches several components — fails
+generation with a message naming the component and the reference, so the graph never silently drops
+or misdirects a declared relationship.
+
+### Deduplication against discovered packages
+
+If a declaration matches a package that `vipm sbom` discovered on its own — the same purl, or the
+same name and version — the discovered package wins (it carries verified installed-state metadata),
+the redundant declaration is dropped with a warning, and any `depends-on` edges from the declaration
+carry over to the surviving component. This also means a declaration whose identity matches a
+discovered package is the supported way to attach dependency edges to that package.
+
+### Knowing where each component came from
+
+Every component in CycloneDX output carries a `vipm:component:source` property naming how it entered
+the SBOM:
+
+| Value | Meaning |
+|-------|---------|
+| `declared` | A `[[sbom.component]]` declaration in `vipm.toml` |
+| `manifest` | A direct dependency from the manifest's dependency tables |
+| `transitive` | Resolved from the lock file as a dependency of another package |
+| `project-scan` | Discovered by scanning a LabVIEW project |
+
+Tools consuming the SBOM can use this to tell user-declared entries from discovered ones — for
+example, to know which components are editable in the manifest.
+
+## Alternative: merging supplemental SBOMs
+
+For component metadata that goes beyond the declaration fields above (file hashes, nested component
+trees, output from other scanners such as `syft` or `cdxgen`), you can maintain a separate CycloneDX
+file and merge it with the `vipm sbom` output using standard CycloneDX merge tooling:
+
+```bash
+vipm sbom vipm.toml --format cyclonedx --output build/labview-bom.json
+
 cyclonedx-cli merge \
   --input-files build/labview-bom.json custom-components.json \
   --output-file build/final-bom.json
 ```
 
-### Other merge tools
-
-Several tools can merge CycloneDX SBOMs:
+Keep the supplemental file in version control alongside your project so the merged result stays
+reproducible.
 
 | Tool | Description |
 |------|-------------|

--- a/docs/sbom/output-reference.md
+++ b/docs/sbom/output-reference.md
@@ -152,7 +152,7 @@ The table below describes each field and where the data originates.
 | `licenses` | Array of license entries. See [License handling](#license-handling). | VIPM: `license` from package spec. NIPM: `Eula` field. |
 | `hashes` | Cryptographic checksums. See [Hash algorithms](#hash-algorithms). | VIPM: cached hashes. NIPM: hash fields from NIPM CLI. |
 | `externalReferences` | Links related to the component. Currently a single `website` entry is emitted when a homepage URL is available. | VIPM: `url` from package spec. NIPM: `Homepage` field. |
-| `properties` | Tool-specific extensions under the `vipm:` namespace — `vipm:display-name` (human-readable package name) and `vipm:display-version` (human-readable version), each emitted when available. | VIPM: `display_name` from package spec (`display_version` not currently populated). NIPM: `DisplayName` and `DisplayVersion` fields. |
+| `properties` | Tool-specific extensions under the `vipm:` namespace — `vipm:display-name` (human-readable package name) and `vipm:display-version` (human-readable version), each emitted when available, plus `vipm:component:source` on every component, naming how it entered the SBOM: `declared` (a `[[sbom.component]]` entry in `vipm.toml`), `manifest` (direct manifest dependency), `transitive` (lock-resolved dependency of another package), or `project-scan` (discovered by scanning a LabVIEW project). See [Custom Components](custom-components.md). | VIPM: `display_name` from package spec (`display_version` not currently populated). NIPM: `DisplayName` and `DisplayVersion` fields. Source channel: determined by the generation pipeline. |
 
 Fields are omitted from the JSON when no data is available (e.g., if a package has no description, the `description` key is absent).
 

--- a/docs/vipm-toml/index.md
+++ b/docs/vipm-toml/index.md
@@ -68,6 +68,7 @@ builds/my_library/MyLibrary.lvlib
 | ✅ **Lock files** | Reproducible builds with `vipm.lock` |
 | ✅ **Build system** | Define PPL, EXE, and package builds in one file |
 | ✅ **CI/CD ready** | `vipm lock --check` for validation |
+| ✅ **SBOM declarations** | Declare non-package-manager components for your SBOM with [`[[sbom.component]]`](../sbom/custom-components.md) |
 
 ## Next Steps
 


### PR DESCRIPTION
The custom-components page told users their only option for DLLs, firmware, and other non-package-manager components was external CycloneDX merge tooling. The CLI now supports declaring these components natively in `vipm.toml`, and users following the current page would miss the simpler supported path entirely.

- Rewrite `docs/sbom/custom-components.md` to lead with `[[sbom.component]]` declarations: schema field reference, `depends-on` dependency edges, deduplication behavior against discovered packages, the `vipm:component:source` origin property, and the never-edit-generated-output guidance. External merge tooling remains as the advanced path for supplemental data beyond the declaration fields.
- Document the `vipm:component:source` property values in `docs/sbom/output-reference.md`.
- Cross-link the declaration syntax from the `vipm.toml` overview page.

Build validated with `just build` (strict, all post-build checks pass).